### PR TITLE
Services: Fix some Deletion methods

### DIFF
--- a/src/album/album.service.spec.ts
+++ b/src/album/album.service.spec.ts
@@ -9,7 +9,7 @@ import AlbumModule from "./album.module";
 import FileManagerService from "src/file-manager/file-manager.service";
 import { FakeFileManagerService } from "test/FakeFileManagerModule";
 import PrismaService from "src/prisma/prisma.service";
-import { AlbumAlreadyExistsException } from "./album.exceptions";
+import { AlbumAlreadyExistsException, AlbumNotFoundException, AlbumNotFoundFromIDException } from "./album.exceptions";
 import Slug from "src/slug/slug";
 import { ArtistNotFoundException } from "src/artist/artist.exceptions";
 
@@ -205,4 +205,25 @@ describe('Album Service', () => {
 			expect(newAlbum.artistId).toBe(albumWithArtist.artistId);
 		});
 	});
+
+	describe('Delete Album', () => {
+		it("should throw, as the album does not exist (by id)", () => {
+			const test = async () => albumService.deleteAlbum({ byId: { id: -1 } });
+			expect(test()).rejects.toThrow(AlbumNotFoundFromIDException); 
+		});
+
+		it("should throw, as the album does not exist (by slug)", () => {
+			const test = async () => albumService.deleteAlbum({ bySlug: { slug: new Slug("Trololol") } });
+			expect(test()).rejects.toThrow(AlbumNotFoundException); 
+		});
+
+		it("should delete the album", async () => {
+			const albumQueryParameters = {
+				bySlug: { slug: new Slug('My new album') }
+			}
+			await albumService.deleteAlbum(albumQueryParameters);
+			const test = async () => albumService.getAlbum(albumQueryParameters);
+			expect(test()).rejects.toThrow(AlbumNotFoundException); 
+		});
+	})
 });

--- a/src/album/album.service.spec.ts
+++ b/src/album/album.service.spec.ts
@@ -225,5 +225,5 @@ describe('Album Service', () => {
 			const test = async () => albumService.getAlbum(albumQueryParameters);
 			expect(test()).rejects.toThrow(AlbumNotFoundException); 
 		});
-	})
+	});
 });

--- a/src/album/album.service.spec.ts
+++ b/src/album/album.service.spec.ts
@@ -9,13 +9,14 @@ import AlbumModule from "./album.module";
 import FileManagerService from "src/file-manager/file-manager.service";
 import { FakeFileManagerService } from "test/FakeFileManagerModule";
 import PrismaService from "src/prisma/prisma.service";
-import { AlbumAlreadyExistsException, AlbumNotFoundException, AlbumNotFoundFromIDException } from "./album.exceptions";
+import { AlbumAlreadyExistsException, AlbumNotFoundFromIDException } from "./album.exceptions";
 import Slug from "src/slug/slug";
 import { ArtistNotFoundException } from "src/artist/artist.exceptions";
 
 describe('Album Service', () => {
 	let albumService: AlbumService;
 	let artistService: ArtistService;
+	let album: Album;
 	beforeAll(async () => {
 		const module: TestingModule = await createTestingModule({
 			imports: [AlbumModule, ArtistModule, PrismaModule],
@@ -61,7 +62,7 @@ describe('Album Service', () => {
 	describe('Create an album', () => {
 		describe('No artist', () => {
 			it('should create an album (no artist)', async () => {
-				let album: Album = await albumService.createAlbum({ name: 'My album' });
+				album = await albumService.createAlbum({ name: 'My album' });
 
 				expect(album.id).toBeDefined();
 				expect(album.artistId).toBeNull();
@@ -212,18 +213,11 @@ describe('Album Service', () => {
 			expect(test()).rejects.toThrow(AlbumNotFoundFromIDException); 
 		});
 
-		it("should throw, as the album does not exist (by slug)", () => {
-			const test = async () => albumService.deleteAlbum({ bySlug: { slug: new Slug("Trololol") } });
-			expect(test()).rejects.toThrow(AlbumNotFoundException); 
-		});
-
 		it("should delete the album", async () => {
-			const albumQueryParameters = {
-				bySlug: { slug: new Slug('My new album') }
-			}
+			const albumQueryParameters = { byId: { id: album.id } };
 			await albumService.deleteAlbum(albumQueryParameters);
 			const test = async () => albumService.getAlbum(albumQueryParameters);
-			expect(test()).rejects.toThrow(AlbumNotFoundException); 
+			expect(test()).rejects.toThrow(AlbumNotFoundFromIDException); 
 		});
 	});
 });

--- a/src/album/album.service.ts
+++ b/src/album/album.service.ts
@@ -129,9 +129,10 @@ export default class AlbumService {
 	 * @param where the query parameter 
 	 */
 	async deleteAlbum(where: AlbumQueryParameters.WhereInput): Promise<void> {
+		let album = await this.getAlbum(where);
 		try {
 			let deletedAlbum = await this.prismaService.album.delete({
-				where: AlbumQueryParameters.buildQueryParametersForOne(where)
+				where: AlbumQueryParameters.buildQueryParametersForOne({ byId: { id: album.id } })
 			});
 			if (deletedAlbum.artistId !== null)
 				this.artistServce.deleteArtistIfEmpty({ id: deletedAlbum.artistId });

--- a/src/album/album.service.ts
+++ b/src/album/album.service.ts
@@ -128,18 +128,15 @@ export default class AlbumService {
 	 * Deletes an album, and its related releases
 	 * @param where the query parameter 
 	 */
-	async deleteAlbum(where: AlbumQueryParameters.WhereInput): Promise<void> {
-		let album = await this.getAlbum(where);
+	async deleteAlbum(where: AlbumQueryParameters.DeleteInput): Promise<void> {
 		try {
 			let deletedAlbum = await this.prismaService.album.delete({
-				where: AlbumQueryParameters.buildQueryParametersForOne({ byId: { id: album.id } })
+				where: AlbumQueryParameters.buildQueryParametersForOne(where)
 			});
 			if (deletedAlbum.artistId !== null)
 				this.artistServce.deleteArtistIfEmpty({ id: deletedAlbum.artistId });
 		} catch {
-			if (where.byId)
-				throw new AlbumNotFoundFromIDException(where.byId.id);
-			throw new AlbumNotFoundException(where.bySlug.slug, where.bySlug.artist?.slug);
+			throw new AlbumNotFoundFromIDException(where.byId.id);
 		}
 	}
 

--- a/src/album/models/album.query-parameters.ts
+++ b/src/album/models/album.query-parameters.ts
@@ -94,6 +94,11 @@ namespace AlbumQueryParameters {
 	export type GetOrCreateInput = CreateInput;
 
 	/**
+	 * Query parameters to delete one album
+	 */
+	 export type DeleteInput = Required<Pick<WhereInput, 'byId'>>;
+
+	/**
 	 * Defines what relations to include in query
 	 */
 	export const AvailableIncludes = ['releases', 'artist'] as const;

--- a/src/artist/artist.service.spec.ts
+++ b/src/artist/artist.service.spec.ts
@@ -107,5 +107,5 @@ describe('Artist Service', () => {
 			const test = async () => artistService.getArtist(albumQueryParameters);
 			expect(test()).rejects.toThrow(ArtistNotFoundException); 
 		});
-	})
+	});
 })

--- a/src/artist/artist.service.spec.ts
+++ b/src/artist/artist.service.spec.ts
@@ -88,7 +88,7 @@ describe('Artist Service', () => {
 		})
 	});
 
-	describe('Delete Album', () => {
+	describe('Delete Artist', () => {
 		it("should throw, as the album does not exist (by id)", () => {
 			const test = async () => artistService.deleteArtist({ id: -1 });
 			expect(test()).rejects.toThrow(ArtistNotFoundByIDException); 

--- a/src/artist/artist.service.spec.ts
+++ b/src/artist/artist.service.spec.ts
@@ -5,7 +5,7 @@ import PrismaModule from "src/prisma/prisma.module";
 import PrismaService from "src/prisma/prisma.service";
 import Slug from "src/slug/slug";
 import { FakeFileManagerService } from "test/FakeFileManagerModule";
-import { ArtistAlreadyExistsException } from "./artist.exceptions";
+import { ArtistAlreadyExistsException, ArtistNotFoundByIDException, ArtistNotFoundException } from "./artist.exceptions";
 import ArtistModule from "./artist.module";
 import ArtistService from "./artist.service"
 
@@ -86,5 +86,26 @@ describe('Artist Service', () => {
 			expect(artist.slug).toBe('my-artist2');
 			expect(artist.id).toBe(artist.id);
 		})
+	});
+
+	describe('Delete Album', () => {
+		it("should throw, as the album does not exist (by id)", () => {
+			const test = async () => artistService.deleteArtist({ id: -1 });
+			expect(test()).rejects.toThrow(ArtistNotFoundByIDException); 
+		});
+
+		it("should throw, as the album does not exist (by slug)", () => {
+			const test = async () => artistService.deleteArtist({ slug: new Slug("Trololol") });
+			expect(test()).rejects.toThrow(ArtistNotFoundException); 
+		});
+
+		it("should delete the album", async () => {
+			const albumQueryParameters = {
+				slug: new Slug("My Name")
+			}
+			await artistService.deleteArtist(albumQueryParameters);
+			const test = async () => artistService.getArtist(albumQueryParameters);
+			expect(test()).rejects.toThrow(ArtistNotFoundException); 
+		});
 	})
 })

--- a/src/file/file.exceptions.ts
+++ b/src/file/file.exceptions.ts
@@ -1,8 +1,8 @@
-import { NotFoundException } from "src/exceptions/meelo-exception";
+import { AlreadyExistsException, NotFoundException } from "src/exceptions/meelo-exception";
 
 export class FileNotFoundFromPathException extends NotFoundException {
 	constructor(filePath: string) {
-		super(`File '${filePath} not found'`);
+		super(`File '${filePath}' not found`);
 	}
 }
 
@@ -15,5 +15,11 @@ export class FileNotFoundFromIDException extends NotFoundException {
 export class FileNotFoundFromTrackIDException extends NotFoundException {
 	constructor(trackId: number) {
 		super(`File from track with id '${trackId} not found'`);
+	}
+}
+
+export class FileAlreadyExistsException extends AlreadyExistsException {
+	constructor(filePath: string, libraryId: number) {
+		super(`File '${filePath}' has already been registered for library n°'${libraryId}'`);
 	}
 }

--- a/src/file/file.service.spec.ts
+++ b/src/file/file.service.spec.ts
@@ -1,0 +1,113 @@
+import type { TestingModule } from "@nestjs/testing";
+import type { Library, File } from "@prisma/client";
+import FileManagerModule from "src/file-manager/file-manager.module";
+import FileManagerService from "src/file-manager/file-manager.service";
+import IllustrationModule from "src/illustration/illustration.module";
+import LibraryModule from "src/library/library.module";
+import LibraryService from "src/library/library.service";
+import MetadataModule from "src/metadata/metadata.module";
+import PrismaModule from "src/prisma/prisma.module";
+import PrismaService from "src/prisma/prisma.service";
+import { FakeFileManagerService } from "test/FakeFileManagerModule";
+import { createTestingModule } from "test/TestModule";
+import { FileAlreadyExistsException, FileNotFoundFromIDException, FileNotFoundFromPathException } from "./file.exceptions";
+import FileModule from "./file.module";
+import FileService from "./file.service";
+
+describe('File Service', () => {
+	let fileService: FileService;
+	let libraryService: LibraryService;
+	let library: Library;
+	let library2: Library;
+	let file1: File;
+	let file2: File;
+	beforeAll(async () => {
+		const module: TestingModule = await createTestingModule({
+			imports: [LibraryModule, PrismaModule, FileModule, MetadataModule, FileManagerModule, IllustrationModule],
+			providers: [FileService, LibraryService],
+		}).overrideProvider(FileManagerService).useClass(FakeFileManagerService).compile();
+		await module.get<PrismaService>(PrismaService).onModuleInit();
+		fileService = module.get<FileService>(FileService);
+		libraryService = module.get<LibraryService>(LibraryService);
+		library = await libraryService.createLibrary({
+			name: 'My Library',
+			path: "."
+		});
+		library2 = await libraryService.createLibrary({
+			name: 'My Library2',
+			path: "Now"
+		});
+	});
+
+	it('should be defined', () => {
+		expect(fileService).toBeDefined();
+		expect(libraryService).toBeDefined();
+	});
+
+	describe('Create File', () => {
+		it('should create a file', async () => {
+			const now = new Date();
+			file1 = await fileService.createFile({
+				path: 'Me',
+				libraryId: library.id,
+				md5Checksum: "Sum",
+				registerDate: now
+			});
+			expect(file1.id).toBeDefined();
+			expect(file1.libraryId).toBe(library.id);
+			expect(file1.md5Checksum).toBe("Sum");
+			expect(file1.path).toBe("Me");
+			expect(file1.registerDate).toStrictEqual(now);
+		});
+
+		it('should throw, as the file in the library already exists', async () => {
+			const now = new Date();
+			const test = async () => await fileService.createFile({
+				path: 'Me',
+				libraryId: library.id,
+				md5Checksum: "Sum",
+				registerDate: now
+			});
+			expect(test()).rejects.toThrow(FileAlreadyExistsException)
+		});
+
+		it('should create a file in another library', async () => {
+			const now = new Date();
+			file2 = await fileService.createFile({
+				path: 'Wow',
+				libraryId: library2.id,
+				md5Checksum: "Sum",
+				registerDate: now
+			});
+			expect(file2.id).toBeDefined();
+			expect(file2.libraryId).toBe(library2.id);
+			expect(file2.md5Checksum).toBe("Sum");
+			expect(file2.path).toBe("Wow");
+			expect(file2.registerDate).toStrictEqual(now);
+		})
+	});
+
+	describe('Delete File', () => {
+		it('should create a file (from path)', async () => {
+			await fileService.deleteFile({ path: "Me" });
+			const test = async () => fileService.getFile({ path: 'Me' });
+			expect(test()).rejects.toThrow(FileNotFoundFromPathException);
+		});
+
+		it('should create a file (from id)', async () => {
+			await fileService.deleteFile({ id: file2.id });
+			const test = async () => fileService.getFile({ id: file2.id });
+			expect(test()).rejects.toThrow(FileNotFoundFromIDException);
+		});
+
+		it('should throw, as the file does not exist (from id)', () => {
+			const test = async () => fileService.deleteFile({ id: -1 });
+			expect(test()).rejects.toThrow(FileNotFoundFromIDException);
+		});
+
+		it('should throw, as the file does not exist (from path)', () => {
+			const test = async () => fileService.deleteFile({ path: '' });
+			expect(test()).rejects.toThrow(FileNotFoundFromPathException);
+		})
+	});
+});

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import FileManagerService from 'src/file-manager/file-manager.service';
-import { FileNotFoundFromIDException, FileNotFoundFromPathException, FileNotFoundFromTrackIDException } from './file.exceptions';
+import { FileAlreadyExistsException, FileNotFoundFromIDException, FileNotFoundFromPathException, FileNotFoundFromTrackIDException } from './file.exceptions';
 import PrismaService from 'src/prisma/prisma.service';
 import type { Library, File } from '@prisma/client';
 import FileQueryParameters from './models/file.query-parameters';
@@ -21,10 +21,14 @@ export default class FileService {
 	 * @returns the saved file
 	 */
 	async createFile(file: FileQueryParameters.CreateInput, include?: FileQueryParameters.RelationInclude): Promise<File> {
-		return await this.prismaService.file.create({
-			data: file,
-			include: FileQueryParameters.buildIncludeParameters(include)
-		});
+		try {
+			return await this.prismaService.file.create({
+				data: file,
+				include: FileQueryParameters.buildIncludeParameters(include)
+			});
+		} catch {
+			throw new FileAlreadyExistsException(file.path, file.libraryId)
+		}
 	}
 
 	/**
@@ -91,12 +95,21 @@ export default class FileService {
 	/**
 	 * Delete a File in the database
 	 * @param where the parameters to get the file to delete
-	 * @returns the deleted file
+	 * @returns an empty promise
 	 */
-	async deleteFile(where: FileQueryParameters.WhereInput): Promise<File> {
-		return this.prismaService.file.delete({
-			where: FileQueryParameters.buildQueryParametersForOne(where)
-		});
+	async deleteFile(where: FileQueryParameters.WhereInput): Promise<void> {
+		try {
+			await this.prismaService.file.delete({
+				where: FileQueryParameters.buildQueryParametersForOne(where)
+			});
+		} catch {
+			if (where.id !== undefined)
+				throw new FileNotFoundFromIDException(where.id);
+			else if (where.trackId !== undefined)
+				throw new FileNotFoundFromTrackIDException(where.trackId);
+			throw new FileNotFoundFromPathException(where.path);
+		}
+		
 	}
 
 	/**

--- a/src/release/models/release.query-parameters.ts
+++ b/src/release/models/release.query-parameters.ts
@@ -90,6 +90,11 @@ namespace ReleaseQueryParameters {
 	export type GetOrCreateInput = CreateInput;
 
 	/**
+	 * Query parameters to delete one release
+	 */
+	 export type DeleteInput = Required<Pick<WhereInput, 'byId'>>;
+
+	/**
 	 * Defines what relations to include in query
 	 */
 	export const AvailableIncludes = ['album', 'tracks'] as const;

--- a/src/release/release.service.spec.ts
+++ b/src/release/release.service.spec.ts
@@ -19,7 +19,9 @@ describe('Release Service', () => {
 	let albumService: AlbumService;
 	let album: Album & { releases: Release[], artist: Artist | null };
 	let compilationAlbum: Album & { releases: Release[], artist: Artist | null };
-	let release: Release & { album: Album };
+	let standardRelease: Release & { album: Album };
+	let deluxeRelease: Release & { album: Album };
+	let editedRelease: Release & { album: Album };
 	let compilationRelease: Release;
 	
 	beforeAll(async () => {
@@ -47,17 +49,17 @@ describe('Release Service', () => {
 	
 	describe('Create a release', () => {
 		it("should create the album's first release", async () => {
-			release = await releaseService.createRelease({
+			deluxeRelease = await releaseService.createRelease({
 				title: 'My Album (Deluxe Edition)',
 				album: { byId: { id: album.id } },
 				releaseDate: new Date('2006'),
 				master: true
 			}, { album: true });
-			expect(release.albumId).toBe(album.id);
-			expect(release.master).toBeTruthy();
-			expect(release.releaseDate).toStrictEqual(new Date('2006'));
-			expect(release.title).toBe('My Album (Deluxe Edition)');
-			expect(release.slug).toBe('my-album-deluxe-edition');
+			expect(deluxeRelease.albumId).toBe(album.id);
+			expect(deluxeRelease.master).toBeTruthy();
+			expect(deluxeRelease.releaseDate).toStrictEqual(new Date('2006'));
+			expect(deluxeRelease.title).toBe('My Album (Deluxe Edition)');
+			expect(deluxeRelease.slug).toBe('my-album-deluxe-edition');
 		});
 
 		it("should create the album's first release (compilation)", async () => {
@@ -75,8 +77,8 @@ describe('Release Service', () => {
 		});
 
 		it("should update the parent album year", async () => {
-			expect(release.album.name).toStrictEqual('My Album');
-			expect(release.album.releaseDate).toStrictEqual(new Date('2006'));
+			expect(deluxeRelease.album.name).toStrictEqual('My Album');
+			expect(deluxeRelease.album.releaseDate).toStrictEqual(new Date('2006'));
 		});
 		
 		it("should create the album's second release", async () => {
@@ -84,22 +86,22 @@ describe('Release Service', () => {
 				{ byId: { id: album.id } },
 				{ releases: true, artist: true }
 			);
-			release = await releaseService.createRelease({
+			standardRelease = await releaseService.createRelease({
 				title: 'My Album',
 				album: { byId: { id: album.id } },
 				releaseDate: new Date('2007'),
 				master: false
 			}, { album: true });
-			expect(release.albumId).toBe(album.id);
-			expect(release.master).toBeFalsy();
-			expect(release.releaseDate).toStrictEqual(new Date('2007'));
-			expect(release.title).toBe('My Album');
-			expect(release.slug).toBe('my-album');
+			expect(standardRelease.albumId).toBe(album.id);
+			expect(standardRelease.master).toBeFalsy();
+			expect(standardRelease.releaseDate).toStrictEqual(new Date('2007'));
+			expect(standardRelease.title).toBe('My Album');
+			expect(standardRelease.slug).toBe('my-album');
 		});
 
 		it("should not have updated the parent album metadata", async () => {
-			expect(release.album.releaseDate).toStrictEqual(new Date('2006'));
-			expect(release.album.name).toStrictEqual('My Album');
+			expect(standardRelease.album.releaseDate).toStrictEqual(new Date('2006'));
+			expect(standardRelease.album.name).toStrictEqual('My Album');
 		});
 	});
 
@@ -107,21 +109,21 @@ describe('Release Service', () => {
 		it("should get the release", async () => {
 			let fetchedRelease = await releaseService.getRelease({
 				bySlug: {
-					slug: new Slug(release.slug),
+					slug: new Slug(deluxeRelease.slug),
 					album: {
 						bySlug: {
-							slug: new Slug(release.album.slug),
+							slug: new Slug(deluxeRelease.album.slug),
 							artist: { slug: new Slug(album.artist!.slug) }
 						}
 					},	
 				}
 			});
-			expect(fetchedRelease.id).toBe(release.id);
-			expect(fetchedRelease.albumId).toBe(release.albumId);
-			expect(fetchedRelease.title).toBe(release.title);
-			expect(fetchedRelease.releaseDate).toStrictEqual(release.releaseDate);
-			expect(fetchedRelease.slug).toBe(release.slug);
-			expect(fetchedRelease.master).toBe(release.master);
+			expect(fetchedRelease.id).toBe(deluxeRelease.id);
+			expect(fetchedRelease.albumId).toBe(deluxeRelease.albumId);
+			expect(fetchedRelease.title).toBe(deluxeRelease.title);
+			expect(fetchedRelease.releaseDate).toStrictEqual(deluxeRelease.releaseDate);
+			expect(fetchedRelease.slug).toBe(deluxeRelease.slug);
+			expect(fetchedRelease.master).toBe(deluxeRelease.master);
 		});
 
 		it("should get the release (compilation)", async () => {
@@ -177,13 +179,13 @@ describe('Release Service', () => {
 		});
 
 		it("should get the release from its id", async () => {
-			let fetchedRelease = await releaseService.getRelease({ byId: { id: release.id } });
-			expect(fetchedRelease.id).toBe(release.id);
-			expect(fetchedRelease.albumId).toBe(release.albumId);
-			expect(fetchedRelease.title).toBe(release.title);
-			expect(fetchedRelease.releaseDate).toStrictEqual(release.releaseDate);
-			expect(fetchedRelease.slug).toBe(release.slug);
-			expect(fetchedRelease.master).toBe(release.master);
+			let fetchedRelease = await releaseService.getRelease({ byId: { id: deluxeRelease.id } });
+			expect(fetchedRelease.id).toBe(deluxeRelease.id);
+			expect(fetchedRelease.albumId).toBe(deluxeRelease.albumId);
+			expect(fetchedRelease.title).toBe(deluxeRelease.title);
+			expect(fetchedRelease.releaseDate).toStrictEqual(deluxeRelease.releaseDate);
+			expect(fetchedRelease.slug).toBe(deluxeRelease.slug);
+			expect(fetchedRelease.master).toBe(deluxeRelease.master);
 		});
 
 		it("should throw, as no release has the id", async () => {
@@ -196,7 +198,7 @@ describe('Release Service', () => {
 
 	describe('Get Master Release', () => {
 		it("Should retrieve the master release", async () => {
-			release = await releaseService.getRelease(
+			deluxeRelease = await releaseService.getRelease(
 				{ byMasterOf: {
 					bySlug: {
 						slug: new Slug(album.slug),
@@ -206,10 +208,10 @@ describe('Release Service', () => {
 				{ album: true }
 			);
 
-			expect(release.albumId).toBe(album.id);
-			expect(release.master).toBe(true);
-			expect(release.title).toBe("My Album (Deluxe Edition)");
-			expect(release.releaseDate).toStrictEqual(new Date('2006'));
+			expect(deluxeRelease.albumId).toBe(album.id);
+			expect(deluxeRelease.master).toBe(true);
+			expect(deluxeRelease.title).toBe("My Album (Deluxe Edition)");
+			expect(deluxeRelease.releaseDate).toStrictEqual(new Date('2006'));
 		});
 
 		it("Should retrieve the master release (compilation)", async () => {
@@ -229,10 +231,10 @@ describe('Release Service', () => {
 		it("Should Update the release", async () => {
 			let updatedRelease = await releaseService.updateRelease(
 				{ title: 'My Album (Special Edition)' },
-				{ byId: { id: release.id } }
+				{ byId: { id: deluxeRelease.id } }
 			);
-			expect(updatedRelease.id).toStrictEqual(release.id);
-			expect(updatedRelease.albumId).toStrictEqual(release.albumId);
+			expect(updatedRelease.id).toStrictEqual(deluxeRelease.id);
+			expect(updatedRelease.albumId).toStrictEqual(deluxeRelease.albumId);
 			expect(updatedRelease.title).toStrictEqual('My Album (Special Edition)');
 			expect(updatedRelease.slug).toBe('my-album-special-edition');
 		});
@@ -240,7 +242,7 @@ describe('Release Service', () => {
 		it("Should Update the album's date", async () => {
 			await releaseService.updateRelease(
 				{ releaseDate: new Date('2005') },
-				{ byId: { id: release.id } }
+				{ byId: { id: deluxeRelease.id } }
 			);
 			album = await albumService.getAlbum(
 				{ bySlug: { slug: new Slug('My Album'), artist: { slug: new Slug ("My Artist") } } },
@@ -250,19 +252,19 @@ describe('Release Service', () => {
 		});
 
 		it("Should Update the master release (unset)", async () => {
-			await releaseService.updateRelease({ master: false }, { byId: { id: release.id } });
+			await releaseService.updateRelease({ master: false }, { byId: { id: deluxeRelease.id } });
 			album = await albumService.getAlbum(
 				{ bySlug: { slug: new Slug('My Album'), artist: { slug: new Slug ("My Artist") } } },
 				{ releases: true }
 			);
-			expect(album.releases.find((release) => release.master == true)!.title).toBe('My Album');
+			expect(album.releases.find((release) => release.master == true)!.id).toBe(standardRelease.id);
 		});
 
 		it("Should Update the master release (set)", async () => {
-			await releaseService.updateRelease({ master: true }, { byId: { id: release.id } });
+			await releaseService.updateRelease({ master: true }, { byId: { id: deluxeRelease.id } });
 			let newMaster = await releaseService.getMasterRelease({ byId: { id: album.id } });
 			expect(newMaster.title).toBe('My Album (Special Edition)');
-			release = newMaster;
+			deluxeRelease = newMaster;
 			let albumReleases = await releaseService.getAlbumReleases({ byId: { id: album.id } });
 			expect(albumReleases.find((release) => release.master == false)!.title).toBe('My Album');
 
@@ -274,7 +276,7 @@ describe('Release Service', () => {
 			let fetchedRelease: Release = await releaseService.getOrCreateRelease({
 				title: 'My Album (Special Edition)', album: { byId: { id: album.id } }, releaseDate: new Date('2008'), master: false
 			});
-			expect(fetchedRelease.id).toBe(release.id);
+			expect(fetchedRelease.id).toBe(deluxeRelease.id);
 			expect(fetchedRelease.master).toBe(true);
 			expect(fetchedRelease.releaseDate).toStrictEqual(new Date('2005'));
 			expect(fetchedRelease.title).toBe("My Album (Special Edition)");
@@ -283,14 +285,14 @@ describe('Release Service', () => {
 		});
 
 		it("should create a new release", async () => {
-			let createdRelease: Release = await releaseService.getOrCreateRelease({
+			editedRelease = await releaseService.getOrCreateRelease({
 				title: 'My Album (Edited Version)', album: { byId: { id: album.id } }, releaseDate: new Date('2007'), master: false
 			});
-			expect(createdRelease.albumId).toBe(album.id);
-			expect(createdRelease.master).toBe(false);
-			expect(createdRelease.releaseDate).toStrictEqual(new Date('2007'));
-			expect(createdRelease.title).toBe("My Album (Edited Version)");
-			expect(createdRelease.slug).toBe('my-album-edited-version');
+			expect(editedRelease.albumId).toBe(album.id);
+			expect(editedRelease.master).toBe(false);
+			expect(editedRelease.releaseDate).toStrictEqual(new Date('2007'));
+			expect(editedRelease.title).toBe("My Album (Edited Version)");
+			expect(editedRelease.slug).toBe('my-album-edited-version');
 		});
 	});
 
@@ -304,26 +306,21 @@ describe('Release Service', () => {
 		});
 
 		it("should delete a release (not master)", async () => {
-			const queryParam = {
-				bySlug: {
-					slug: new Slug('My Album (Edited Version)'),
-					album: { byId: { id: album.id } }
-				}
-			};
+			const queryParam = { byId: { id: editedRelease.id } };
 			await releaseService.deleteRelease(queryParam);
 			const testRelease = async () => await releaseService.getRelease(queryParam);
-			expect(testRelease()).rejects.toThrow(ReleaseNotFoundException);
+			expect(testRelease()).rejects.toThrow(ReleaseNotFoundFromIDException);
 			/// To check album still exists
 			let master = await releaseService.getMasterRelease({ byId: { id: album.id } });
-			expect(master.id).toBe(release.id);
+			expect(master.id).toBe(deluxeRelease.id);
 		});
 
 		it("should delete master release, and update master status", async () => {
-			await releaseService.deleteRelease({ byId: { id: release.id } });
+			await releaseService.deleteRelease({ byId: { id: deluxeRelease.id } });
 			const testRelease = async () => await releaseService.getRelease({ byId: { id: album.id } });
 			expect(testRelease()).rejects.toThrow(ReleaseNotFoundFromIDException);
 			let updatedSecondRelease =  await releaseService.getMasterRelease({ byId: { id: album.id } });
-			expect(updatedSecondRelease.title).toBe('My Album');
+			expect(updatedSecondRelease.id).toBe(standardRelease.id);
 		});
 	});
 })

--- a/src/release/release.service.ts
+++ b/src/release/release.service.ts
@@ -150,13 +150,10 @@ export default class ReleaseService {
 	 * Also delete related tracks.
 	 * @param where Query parameters to find the release to delete 
 	 */
-	 async deleteRelease(where: ReleaseQueryParameters.WhereInput): Promise<void> {
-		let release = await this.getRelease(where);
+	 async deleteRelease(where: ReleaseQueryParameters.DeleteInput): Promise<void> {
 		try {
 			let deletedRelease = await this.prismaService.release.delete({
-				where: ReleaseQueryParameters.buildQueryParametersForOne({
-					byId: { id: release.id }
-				}),
+				where: ReleaseQueryParameters.buildQueryParametersForOne(where),
 			});
 			if (deletedRelease.master)
 				await this.unsetReleaseAsMaster({
@@ -174,7 +171,7 @@ export default class ReleaseService {
 	 * Deletes a release if it does not have related tracks
 	 * @param where the query parameters to find the track to delete 
 	 */
-	async deleteReleaseIfEmpty(where: ReleaseQueryParameters.WhereInput): Promise<void> {
+	async deleteReleaseIfEmpty(where: ReleaseQueryParameters.DeleteInput): Promise<void> {
 		const trackCount = await this.prismaService.track.count({
 			where: {
 				release: ReleaseQueryParameters.buildQueryParametersForOne(where)

--- a/src/release/release.service.ts
+++ b/src/release/release.service.ts
@@ -161,8 +161,7 @@ export default class ReleaseService {
 					album: { byId: { id: deletedRelease.albumId } }
 				});
 			await this.albumService.deleteAlbumIfEmpty(deletedRelease.albumId);
-		} catch (e) {
-			console.log(e);
+		} catch {
 			throw await this.getReleaseNotFoundError(where);
 		}
 	}

--- a/src/release/release.service.ts
+++ b/src/release/release.service.ts
@@ -151,17 +151,21 @@ export default class ReleaseService {
 	 * @param where Query parameters to find the release to delete 
 	 */
 	 async deleteRelease(where: ReleaseQueryParameters.WhereInput): Promise<void> {
+		let release = await this.getRelease(where);
 		try {
 			let deletedRelease = await this.prismaService.release.delete({
-				where: ReleaseQueryParameters.buildQueryParametersForOne(where),
+				where: ReleaseQueryParameters.buildQueryParametersForOne({
+					byId: { id: release.id }
+				}),
 			});
 			if (deletedRelease.master)
-				this.unsetReleaseAsMaster({
+				await this.unsetReleaseAsMaster({
 					releaseId: deletedRelease.id,
 					album: { byId: { id: deletedRelease.albumId } }
 				});
-			this.albumService.deleteAlbumIfEmpty(deletedRelease.albumId);
-		} catch {
+			await this.albumService.deleteAlbumIfEmpty(deletedRelease.albumId);
+		} catch (e) {
+			console.log(e);
 			throw await this.getReleaseNotFoundError(where);
 		}
 	}

--- a/src/song/song.service.spec.ts
+++ b/src/song/song.service.spec.ts
@@ -239,9 +239,40 @@ describe('Song Service', () => {
 		});
 	});
 
+	describe("Get or Create Song", () => {
+		it("should get the song", async () => {
+			let fetchedSong = await songService.getOrCreateSong({...song, artist: { id: artist.id } });
+			expect(fetchedSong.id).toStrictEqual(song.id);
+			expect(fetchedSong.slug).toStrictEqual(song.slug);
+			expect(fetchedSong.name).toStrictEqual(song.name);
+		});
+
+		it("should create the song", async () => {
+			let createdSong = await songService.getOrCreateSong({
+				name: "My Song 2", artist: { slug: new Slug("My Artist") }
+			});
+			expect(createdSong.name).toBe("My Song 2")
+			expect(createdSong.artistId).toBe(artist.id);
+		});
+
+		it("should thorw as the parent artist does not exist ", async () => {
+			const test = async () => await songService.getOrCreateSong({
+				name: "My Song 3", artist: { slug: new Slug("My Slug") }
+			});
+			expect(test()).rejects.toThrow(ArtistNotFoundException);
+		});
+	});
+
 	describe("Delete Song", () => {
-		it("should delete the song", async () => {
+		it("should delete the song (by id)", async () => {
 			await songService.deleteSong({ byId: { id :song2.id }});
+
+			const test = async () => await songService.getSong({ byId: { id: song2.id } });
+			expect(test()).rejects.toThrow(SongNotFoundByIdException);
+		});
+
+		it("should delete the song (by slug)", async () => {
+			await songService.deleteSong({ bySlug: { slug: new Slug(song.slug), artist: { id: artist.id } }});
 
 			const test = async () => await songService.getSong({ byId: { id: song2.id } });
 			expect(test()).rejects.toThrow(SongNotFoundByIdException);
@@ -264,30 +295,6 @@ describe('Song Service', () => {
 				bySlug: { slug: new Slug('My Song'), artist: { slug: new Slug("My Artist") } }
 			});
 			expect(test()).rejects.toThrow(SongNotFoundException);
-		});
-	});
-
-	describe("Get or Create Song", () => {
-		it("should get the song", async () => {
-			let fetchedSong = await songService.getOrCreateSong({...song, artist: { id: artist.id } });
-			expect(fetchedSong.id).toStrictEqual(song.id);
-			expect(fetchedSong.slug).toStrictEqual(song.slug);
-			expect(fetchedSong.name).toStrictEqual(song.name);
-		});
-
-		it("should create the song", async () => {
-			let createdSong = await songService.getOrCreateSong({
-				name: "My Song 2", artist: { slug: new Slug("My Artist") }
-			});
-			expect(createdSong.name).toBe("My Song 2")
-			expect(createdSong.artistId).toBe(artist.id);
-		});
-
-		it("should thorw as the parent artist does not exist ", async () => {
-			const test = async () => await songService.getOrCreateSong({
-				name: "My Song 3", artist: { slug: new Slug("My Slug") }
-			});
-			expect(test()).rejects.toThrow(ArtistNotFoundException);
 		});
 	});
 });

--- a/src/song/song.service.ts
+++ b/src/song/song.service.ts
@@ -120,9 +120,10 @@ export default class SongService {
 	 * @param where Query parameters to find the song to delete 
 	 */
 	async deleteSong(where: SongQueryParameters.WhereInput): Promise<void> {
+		let song = await this.getSong(where);
 		try {
 			let deletedSong = await this.prismaService.song.delete({
-				where: SongQueryParameters.buildQueryParametersForOne(where)
+				where: SongQueryParameters.buildQueryParametersForOne({ byId: { id: song.id } })
 			});
 			await this.artistService.deleteArtistIfEmpty({ id: deletedSong.artistId });
 		} catch {

--- a/src/track/models/track.query-parameters.ts
+++ b/src/track/models/track.query-parameters.ts
@@ -89,6 +89,11 @@ namespace TrackQueryParameters {
 	};
 
 	/**
+	 * Query parameters to delete one track
+	 */
+	 export type DeleteInput = RequireOnlyOne<Pick<WhereInput, 'id' | 'sourceFile'>>;
+
+	/**
 	 * Defines what relations to include in query
 	 */
 	 export const AvailableIncludes = ['song', 'release'] as const;

--- a/src/track/track.service.spec.ts
+++ b/src/track/track.service.spec.ts
@@ -387,5 +387,10 @@ describe('Track Service', () => {
 			const test = async () => await songService.getSong({ byId: { id: song.id }});
 			expect(test()).rejects.toThrow(SongNotFoundByIdException);
 		});
+
+		it("should throw, as the track does not exists", async () => {
+			const test = async () => await trackService.getTrack({ id: -1 });
+			expect(test()).rejects.toThrow(TrackNotFoundByIdException);
+		});
 	});
 });

--- a/src/track/track.service.ts
+++ b/src/track/track.service.ts
@@ -170,17 +170,16 @@ export default class TrackService {
 	 * Deletes a track
 	 * @param where Query parameters to find the track to delete 
 	 */
-	 async deleteTrack(where: TrackQueryParameters.WhereInput): Promise<void> {
+	 async deleteTrack(where: TrackQueryParameters.DeleteInput): Promise<void> {
 		try {
-			const trackToDelete = await this.getTrack(where);
-			if (trackToDelete.master)
-				await this.unsetTrackAsMaster({
-					trackId: trackToDelete.id,
-					song: { byId: { id: trackToDelete.songId } }
-				});
 			let deletedTrack = await this.prismaService.track.delete({
 				where: TrackQueryParameters.buildQueryParametersForOne(where),
 			});
+			if (deletedTrack.master)
+				await this.unsetTrackAsMaster({
+					trackId: deletedTrack.id,
+					song: { byId: { id: deletedTrack.songId } }
+				});
 			await Promise.allSettled([
 				this.songService.deleteSongIfEmpty({ byId: { id: deletedTrack.songId } }),
 				this.releaseService.deleteReleaseIfEmpty({ byId: { id: deletedTrack.releaseId } })


### PR DESCRIPTION
Deletion methods used to take the same input as 'getOne' and 'getMany' methods.
However, Prisma and their 'uniqueWhereInput's are not compatible with these methods, which would cause runtime errors

Therefore, incompatible methods now take a dedicated input, derived from the related 'WhereInput' 