### PR TITLE
Front: Fix 'prepareMeeloQuery'

### DIFF
--- a/front/src/api.ts
+++ b/front/src/api.ts
@@ -324,7 +324,7 @@ export default class API {
 	): Promise<T> {
 		return API.fetch<T>({
 			route: `/artists/${slugOrId}`,
-			errorMessage: 'Artists could not be loaded',
+			errorMessage: 'Artist could not be loaded',
 			parameters: { include }
 		});
 	}

--- a/front/src/query.ts
+++ b/front/src/query.ts
@@ -26,7 +26,7 @@ const defaultMeeloQueryOptions = {
  * @returns 
  */
 const prepareMeeloQuery = <T,>(query: MeeloQueryFn<T>, ...queryArgs: Partial<Parameters<typeof query>>) => {
-	const enabled = queryArgs.findIndex((elem) => elem === undefined) === -1;
+	const enabled = isEnabled(queryArgs);
 	const queryParams = query(...queryArgs as Parameters<typeof query>);
 	return {
 		queryKey: queryParams.key,
@@ -37,13 +37,22 @@ const prepareMeeloQuery = <T,>(query: MeeloQueryFn<T>, ...queryArgs: Partial<Par
 }
 
 /**
+ * Using the query parameters, defines if a query should be enabled or not
+ * @param args 
+ * @returns 
+ */
+const isEnabled = (args: any[]) => {
+	return args.findIndex((elem) => (elem === undefined || elem === null)) === -1;
+}
+
+/**
  * Wrapper for 'react-query''s useInfiniteQuery's parameters, to manage dependent queries more easily
  * @param query the function that prepare the query
  * @param queryArgs the arguments to pass the the query function. If one of them is undefined, the query will not be enabled
  * @returns 
  */
 const prepareMeeloInfiniteQuery = <T,>(query: MeeloInfiniteQueryFn<T>, ...queryArgs: Partial<Parameters<typeof query>>) => {
-	const enabled = queryArgs.findIndex((elem) => elem === undefined) === -1;
+	const enabled = isEnabled(queryArgs);
 	const queryParams = query(...queryArgs as Parameters<typeof query>);
 	return {
 		queryKey: queryParams.key,


### PR DESCRIPTION
'prepareMeeloQuery' would return a ReactQuery's Query as disabled when one of the query's parameters is undefined.
Now, it will also disable a query if a parameter is null. This happens on a compilation release's page, where the artist's id is null