### PR TITLE
Front: Fix Library Selection

### DIFF
--- a/front/src/components/player/player.tsx
+++ b/front/src/components/player/player.tsx
@@ -38,11 +38,12 @@ const Player = () => {
 	}, [currentTrack]);
 	if (playlist.length == 0 && history.length == 0 && audio.current == undefined)
 		return <></>
+	console.log(currentTrack?.track.illustration);
 	return <Slide direction="up" in={true} mountOnEnter unmountOnExit>
 		<BottomNavigation>
 			<Paper elevation={20} sx={{ width: '90%', borderRadius: '0.5rem', position: "fixed", bottom: 16, zIndex: 'modal' }}>
 				<PlayerControls
-					illustration={currentTrack?.track.illustration}
+					illustration={currentTrack?.track.illustration ?? currentTrack?.release.illustration}
 					title={currentTrack?.track.name}
 					artist={currentTrack?.artist.name}
 					playing={playing ?? false}

--- a/front/src/components/player/player.tsx
+++ b/front/src/components/player/player.tsx
@@ -38,7 +38,6 @@ const Player = () => {
 	}, [currentTrack]);
 	if (playlist.length == 0 && history.length == 0 && audio.current == undefined)
 		return <></>
-	console.log(currentTrack?.track.illustration);
 	return <Slide direction="up" in={true} mountOnEnter unmountOnExit>
 		<BottomNavigation>
 			<Paper elevation={20} sx={{ width: '90%', borderRadius: '0.5rem', position: "fixed", bottom: 16, zIndex: 'modal' }}>

--- a/front/src/pages/albums/index.tsx
+++ b/front/src/pages/albums/index.tsx
@@ -53,6 +53,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
 const LibraryAlbumsPage = ({ librarySlug }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
 	const router = useRouter();
+	librarySlug ??= getLibrarySlug(router.asPath);
 	const [order, setOrder] = useState(getOrderParams(router.query.order));
 	const [sortBy, setSortBy] = useState(getSortingFieldParams(router.query.sortBy, AlbumSortingFields));
 	return (

--- a/front/src/pages/artists/index.tsx
+++ b/front/src/pages/artists/index.tsx
@@ -48,6 +48,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
 const LibraryArtistsPage = ({ librarySlug }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
 	const router = useRouter();
+	librarySlug ??= getLibrarySlug(router.asPath);
 	const [order, setOrder] = useState(getOrderParams(router.query.order));
 	const [sortBy, setSortBy] = useState(getSortingFieldParams(router.query.sortBy, ArtistSortingFields));
 	return (

--- a/front/src/pages/songs/index.tsx
+++ b/front/src/pages/songs/index.tsx
@@ -50,6 +50,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
 const LibrarySongsPage = ({ librarySlug }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
 	const router = useRouter();
+	librarySlug ??= getLibrarySlug(router.asPath);
 	const [order, setOrder] = useState(getOrderParams(router.query.order));
 	const [sortBy, setSortBy] = useState(getSortingFieldParams(router.query.sortBy, SongSortingFields));
 	return (


### PR DESCRIPTION
Faulty selection was caused by using a parameter from SSR when the page was not hydrated. Therefore, it would always select the 'global' library.

When SSR Props return a null library slug, reparse the url to get it.

Closes #225 