### PR TITLE
Automatically set items as master according to their release data

### DIFF
--- a/src/album/album.service.ts
+++ b/src/album/album.service.ts
@@ -149,6 +149,26 @@ export default class AlbumService extends RepositoryService<
 	}
 
 	/**
+	 * Updates an album master, using the earliest date from its releases
+	 * @param where the query parameter to get the album to update
+	 */
+	 async updateAlbumMaster(where: AlbumQueryParameters.WhereInput): Promise<Release | null> {
+		let releases = await this.releaseService.getAlbumReleases(where);
+		const masterRelease = releases.find((releases) => releases.master);
+		if (!masterRelease)
+			return null;
+		const sortedReleases = releases
+			.filter((releases) => releases.releaseDate !== null)
+			.sort((releaseA, releaseB) => releaseA.releaseDate!.getTime() - releaseB.releaseDate!.getTime())
+		if (sortedReleases.length !== 0) {
+			const newMaster = sortedReleases.at(0)!
+			await this.releaseService.setReleaseAsMaster({ releaseId: newMaster.id, album: where });
+			return newMaster;
+		}
+		return null;
+	}
+
+	/**
 	 * Deletes an album
 	 * @param where the query parameter 
 	 */

--- a/src/metadata/metadata.service.ts
+++ b/src/metadata/metadata.service.ts
@@ -90,7 +90,7 @@ export default class MetadataService {
 		await this.albumService.update({ ...release.album }, { byId: { id: release.albumId }});
 		if (!release.releaseDate || ((metadata.releaseDate) && release.releaseDate < metadata.releaseDate))
 			await this.releaseService.update({ releaseDate: metadata.releaseDate }, { byId: { id: release.id } });
-		return this.trackService.create(track);
+		return this.trackService.create(track).finally(() => this.songService.resetMasterTrack({ byId: { id: song.id } }));
 	}
 
 	/**

--- a/src/metadata/metadata.service.ts
+++ b/src/metadata/metadata.service.ts
@@ -88,8 +88,8 @@ export default class MetadataService {
 			release.album.releaseDate = release.releaseDate;
 		release.album.type = metadata.compilation ? AlbumType.Compilation : release.album.type;
 		await this.albumService.update({ ...release.album }, { byId: { id: release.albumId }});
-		release.releaseDate = metadata.releaseDate ?? null;
-		await this.releaseService.update({ releaseDate: release.releaseDate ?? undefined }, { byId: { id: release.id } });
+		if (!release.releaseDate || ((metadata.releaseDate) && release.releaseDate < metadata.releaseDate))
+			await this.releaseService.update({ releaseDate: metadata.releaseDate }, { byId: { id: release.id } });
 		return this.trackService.create(track);
 	}
 

--- a/src/release/release.service.ts
+++ b/src/release/release.service.ts
@@ -49,6 +49,7 @@ export default class ReleaseService extends RepositoryService<
 	) {
 		const release = await super.create(input, include);
 		await this.albumService.updateAlbumDate({ byId: { id: release.albumId }});
+		await this.albumService.updateAlbumMaster({ byId: { id: release.albumId }});
 		return release;
 
 	}

--- a/src/song/song.service.ts
+++ b/src/song/song.service.ts
@@ -191,7 +191,7 @@ export default class SongService extends RepositoryService<
 			await this.trackService.setTrackAsMaster({ trackId: newMaster.id, song: where });
 			return newMaster;
 		}
-		return null
+		return null;
 	}
 
 	/**

--- a/src/track/track.service.ts
+++ b/src/track/track.service.ts
@@ -162,10 +162,10 @@ export default class TrackService extends RepositoryService<
 	 * @param include the relation to include in the returned objects
 	 * @returns the list of tracks related to the song
 	 */
-	async getSongTracks(
+	async getSongTracks<I extends TrackQueryParameters.RelationInclude>(
 		where: SongQueryParameters.WhereInput,
 		pagination?: PaginationParameters,
-		include?: TrackQueryParameters.RelationInclude,
+		include?: I,
 		sort?: TrackQueryParameters.SortingParameter
 	) {
 		const tracks = await this.getMany(


### PR DESCRIPTION
- A release will automatically be set a master if it is the oldest
- A track will automatically be set as master if it is the older (using the parent release)
- Release date use the earliest date from file metadata
Closes #175 
Closes #174
Closes #241