### PR TITLE
Better album videos select

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17
+FROM node:18
 WORKDIR /app
 RUN apt-get update && apt-get install -y ffmpeg nginx
 COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/front/src/api/api.ts
+++ b/front/src/api/api.ts
@@ -529,14 +529,13 @@ export default class API {
 	 * @param albumSlugOrId the id of the album
 	 * @returns an array of videos
 	 */
-	static async getAlbumVideos(
+	static async getAlbumVideos<T extends Track = Track>(
 		albumSlugOrId: string | number,
-		pagination?: PaginationParameters,
-		sort?: SortingParameters<typeof TrackSortingKeys>,
-	): Promise<PaginatedResponse<Track>> {
+		include: TrackInclude[] = []
+	): Promise<T[]> {
 		return API.fetch({
 			route: `/albums/${albumSlugOrId}/videos`,
-			parameters: { pagination, include: [], sort }
+			parameters: { include }
 		});
 	}
 

--- a/front/src/api/api.ts
+++ b/front/src/api/api.ts
@@ -49,7 +49,7 @@ export default class API {
 	 */
 	private static isSSR = () => typeof window === 'undefined';
 	private static isDev = () => process.env.NODE_ENV === 'development';
-
+	private static SSR_API_URL = process.env.ssrApiRoute!;
 	static defaultPageSize = 30;
 
 	static async login(credentials: AuthenticationInput): Promise<AuthenticationResponse> {
@@ -796,7 +796,7 @@ export default class API {
 	 */
 	static getIllustrationURL(imageURL: string): string {
 		if (API.isDev()) {
-			return `${process.env.ssrApiRoute}${imageURL}`;
+			return `${this.SSR_API_URL}${imageURL}`;
 		}
 		return `/api/${imageURL}`;
 	}
@@ -862,7 +862,7 @@ export default class API {
 	private static buildURL(
 		route: string, parameters: QueryParameters<any>, otherParameters?: any
 	): string {
-		const apiHost = API.isDev() || API.isSSR() ? process.env.ssrApiRoute : '/api';
+		const apiHost = API.isDev() || API.isSSR() ? this.SSR_API_URL : '/api';
 
 		return `${apiHost}${route}${this.formatQueryParameters(parameters, otherParameters)}`;
 	}

--- a/front/src/api/api.ts
+++ b/front/src/api/api.ts
@@ -66,8 +66,7 @@ export default class API {
 			route: '/users/new',
 			data: {
 				name: credentials.username,
-				password: credentials.password,
-				admin: false
+				password: credentials.password
 			},
 			parameters: {}
 		}, 'POST');

--- a/front/src/components/authentication/authentication-form.tsx
+++ b/front/src/components/authentication/authentication-form.tsx
@@ -51,7 +51,6 @@ const AuthenticationForm = () => {
 					{...registerState('username')}
 					textFieldProps={{
 						label: 'Username',
-						color: 'secondary'
 					}}
 					gridProps={{}}
 					rules={{
@@ -70,7 +69,6 @@ const AuthenticationForm = () => {
 					textFieldProps={{
 						label: 'Password',
 						type: 'password',
-						color: 'secondary',
 						onChange: (event) => setPassword(event.target.value)
 					}}
 					gridProps={{}}
@@ -91,7 +89,6 @@ const AuthenticationForm = () => {
 					textFieldProps={{
 						label: 'Confirm',
 						type: 'password',
-						color: 'secondary'
 					}}
 					gridProps={{}}
 					rules={{
@@ -108,13 +105,13 @@ const AuthenticationForm = () => {
 				/>
 				}
 				<Grid item>
-					<Button type="submit" color='secondary' variant='contained' onClick={() => {}}>
+					<Button type="submit" variant='contained' onClick={() => {}}>
 						{formType == 'login' ? 'Login' : 'Signup'}
 					</Button>
 				</Grid>
 				<Divider sx={{ width: '100%', paddingY: 1 }} variant='middle'/>
 				<Grid item>
-					<Button color='secondary' variant='outlined'
+					<Button variant='outlined'
 						onClick={() => setFormType(formType == 'login' ? 'signup' : 'login')}
 					>
 						{formType == 'login' ? "New here ? Signup" : 'Already have an account ? Login'}

--- a/front/src/components/list-item/item.tsx
+++ b/front/src/components/list-item/item.tsx
@@ -19,7 +19,7 @@ const textStyle = {
 };
 
 const ListItem = (props: ListItemProps) => {
-	let clickableArea = <Button color='secondary' onClick={props.onClick}
+	let clickableArea = <Button onClick={props.onClick}
 		sx={{ textTransform: 'none', alignItems: 'center', width: '100%' }}
 	>
 		<Grid container columns={10} spacing={2}

--- a/front/src/components/loading/loading.tsx
+++ b/front/src/components/loading/loading.tsx
@@ -22,7 +22,7 @@ const LoadingComponent = () => {
 		<Bars
 			height="40"
 			width="40"
-			color={theme.palette.primary.contrastText}
+			color={theme.palette.text.primary}
 			ariaLabel="bars-loading"
 		/>
 	</FadeIn>;

--- a/front/src/components/settings/libraries-settings.tsx
+++ b/front/src/components/settings/libraries-settings.tsx
@@ -42,7 +42,7 @@ const LibrariesSettings = () => {
 		{ field: 'clean', headerName: 'Clean', flex: 3, renderCell: ({ row: library }) => {
 			const cleanAction = CleanLibraryAction(library.id);
 
-			return <Button variant='outlined' color='secondary' size='small'
+			return <Button variant='outlined' size='small'
 				startIcon={cleanAction.icon} onClick={cleanAction.onClick} sx={actionButtonStyle}
 			>
 				<Hidden smDown>{cleanAction.label}</Hidden>
@@ -51,7 +51,7 @@ const LibrariesSettings = () => {
 		{ field: 'scan', headerName: 'Scan', flex: 3, renderCell: ({ row: library }) => {
 			const scanAction = ScanLibraryAction(library.id);
 
-			return <Button variant='contained' color='secondary' size='small'
+			return <Button variant='contained' size='small'
 				startIcon={scanAction.icon} onClick={scanAction.onClick}
 				sx={actionButtonStyle}
 			>
@@ -77,14 +77,14 @@ const LibrariesSettings = () => {
 	return <Box sx={{ paddingBottom: 2 }}>
 		<Grid container sx={{ justifyContent: { xs: 'space-evenly', md: 'flex-end' }, paddingY: 2 }} spacing={{ xs: 1, md: 2 }}>
 			<Grid item>
-				<Button variant='outlined' color='secondary'
+				<Button variant='outlined'
 					startIcon={cleanAllLibaries.icon} onClick={cleanAllLibaries.onClick}
 				>
 					{cleanAllLibaries.label}
 				</Button>
 			</Grid>
 			<Grid item>
-				<Button variant='contained' color='secondary'
+				<Button variant='contained'
 					startIcon={scanAllLibaries.icon} onClick={scanAllLibaries.onClick}
 				>
 					{scanAllLibaries.label}

--- a/front/src/components/settings/libraries-settings.tsx
+++ b/front/src/components/settings/libraries-settings.tsx
@@ -1,6 +1,6 @@
 import { Delete } from "@mui/icons-material";
 import {
-	Box, Button, Grid, Hidden, IconButton
+	Box, Button, Grid, Hidden, IconButton, useMediaQuery, useTheme
 } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 import toast from "react-hot-toast";
@@ -14,6 +14,7 @@ import {
 	ScanAllLibrariesAction, ScanLibraryAction
 } from "../actions/library-task";
 import { useConfirm } from "material-ui-confirm";
+import Action from "../actions/action";
 
 const librariesQuery = () => ({
 	key: ['libraries'],
@@ -23,6 +24,21 @@ const librariesQuery = () => ({
 const actionButtonStyle = {
 	overflow: 'hidden',
 	textOverflow: 'ellipsis'
+};
+
+const RunTaskButton = (
+	{ icon, label, onClick, variant }: Action & Pick<Parameters<typeof Button>[0], 'variant'>
+) => {
+	const theme = useTheme();
+	const viewPortIsSmall = useMediaQuery(theme.breakpoints.up('sm'));
+
+	return <Button variant={variant} size='small'
+		startIcon={viewPortIsSmall && icon}
+		onClick={onClick} sx={actionButtonStyle}
+	>
+		<Hidden smUp>{icon}</Hidden>
+		<Hidden smDown>{label}</Hidden>
+	</Button>;
 };
 
 const LibrariesSettings = () => {
@@ -39,25 +55,10 @@ const LibrariesSettings = () => {
 			}));
 	const columns: GridColDef<Library>[] = [
 		{ field: 'name', headerName: 'Name', flex: 5 },
-		{ field: 'clean', headerName: 'Clean', flex: 3, renderCell: ({ row: library }) => {
-			const cleanAction = CleanLibraryAction(library.id);
-
-			return <Button variant='outlined' size='small'
-				startIcon={cleanAction.icon} onClick={cleanAction.onClick} sx={actionButtonStyle}
-			>
-				<Hidden smDown>{cleanAction.label}</Hidden>
-			</Button>;
-		} },
-		{ field: 'scan', headerName: 'Scan', flex: 3, renderCell: ({ row: library }) => {
-			const scanAction = ScanLibraryAction(library.id);
-
-			return <Button variant='contained' size='small'
-				startIcon={scanAction.icon} onClick={scanAction.onClick}
-				sx={actionButtonStyle}
-			>
-				<Hidden smDown>{scanAction.label}</Hidden>
-			</Button>;
-		} },
+		{ field: 'clean', headerName: 'Clean', flex: 3, renderCell: ({ row: library }) =>
+			<RunTaskButton variant='outlined' {...CleanLibraryAction(library.id)}/> },
+		{ field: 'scan', headerName: 'Scan', flex: 3, renderCell: ({ row: library }) =>
+			<RunTaskButton variant='contained' {...ScanLibraryAction(library.id)}/> },
 		{ field: 'delete', headerName: 'Delete', flex: 1, renderCell: ({ row: library }) => {
 			return <IconButton color='error' onClick={() => confirm({
 				title: 'Delete a Library',

--- a/front/src/components/settings/users-settings.tsx
+++ b/front/src/components/settings/users-settings.tsx
@@ -82,7 +82,7 @@ const UsersSettings = () => {
 			</Typography>;
 		} },
 		{ field: 'enabled', headerName: 'Enabled', flex: 2, renderCell: ({ row: user }) => {
-			return <Checkbox checked={user.enabled} color='secondary'
+			return <Checkbox checked={user.enabled}
 				disabled={user.id == currentUser?.id}
 				onChange={(event) => userMutation.mutate(
 					{ user, status: { enabled: event.target.checked } }
@@ -90,7 +90,7 @@ const UsersSettings = () => {
 			/>;
 		} },
 		{ field: 'admin', headerName: 'Admin', flex: 2, renderCell: ({ row: user }) => {
-			return <Checkbox checked={user.admin} color='secondary'
+			return <Checkbox checked={user.admin}
 				disabled={user.id == currentUser?.id}
 				onChange={(event) => userMutation.mutate(
 					{ user, status: { admin: event.target.checked } }

--- a/front/src/components/track-file-info.tsx
+++ b/front/src/components/track-file-info.tsx
@@ -63,8 +63,7 @@ const openTrackFileInfoModal = (
 ) => confirm({
 	title: "Track Information",
 	description: <TrackFileInfo trackId={trackId}/>,
-	cancellationButtonProps: { sx: { display: 'none' } },
-	confirmationButtonProps: { color: 'secondary' }
+	cancellationButtonProps: { sx: { display: 'none' } }
 });
 
 export default TrackFileInfo;

--- a/front/src/pages/_app.tsx
+++ b/front/src/pages/_app.tsx
@@ -52,7 +52,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
 				<AuthenticationWall>
 					<ConfirmProvider defaultOptions={{
 						cancellationButtonProps: {
-							color: 'secondary', sx: { marginX: 2 }
+							sx: { marginX: 2 }
 						},
 					}}>
 						<MeeloAppBar/>

--- a/front/src/pages/artists/[slugOrId]/index.tsx
+++ b/front/src/pages/artists/[slugOrId]/index.tsx
@@ -26,7 +26,7 @@ const SongButton = (props: SongButtonProps) => {
 
 	return <Grid container sx={{ alignItems: 'center' }}>
 		<Grid item xs={10}>
-			<Button color='secondary'
+			<Button
 				sx={{ textTransform: 'none', alignItems: 'center', width: '100%' }}
 				onClick={() => {
 					API.getMasterTrack<TrackWithRelease>(props.song.id, ['release']).then((track) => {
@@ -139,7 +139,7 @@ const ArtistPage = (
 					<Typography variant='h5' fontWeight='bold'>Top Songs</Typography>
 					{ topSongs.data?.metadata.next &&
 					<Link href={`/artists/${artistIdentifier}/songs`}>
-						<Button variant='contained' endIcon={<ArrowRight/>} color='secondary'
+						<Button variant='contained' endIcon={<ArrowRight/>}
 							sx={{ textTransform: 'none', fontWeight: 'bold' }}>See all</Button>
 					</Link>
 					}
@@ -164,7 +164,7 @@ const ArtistPage = (
 					<Typography variant='h5' fontWeight='bold'>Albums</Typography>
 					{ latestAlbums.data?.metadata.next &&
 					<Link href={`/artists/${artistIdentifier}/albums`}>
-						<Button variant='contained' endIcon={<ArrowRight/>} color='secondary'
+						<Button variant='contained' endIcon={<ArrowRight/>}
 							sx={{ textTransform: 'none', fontWeight: 'bold' }}>See all</Button>
 					</Link>
 					}

--- a/front/src/pages/releases/[slugOrId].tsx
+++ b/front/src/pages/releases/[slugOrId].tsx
@@ -178,7 +178,12 @@ const ReleasePage = (
 					</Grid>
 					{albumArtist.data &&
 						<Grid item>
-							<Typography variant='h4'>{albumArtist.data?.name}</Typography>
+							<Link href={`/artists/${albumArtist.data.slug}`}>
+								<Button variant='text' sx={{ textTransform: 'none' }}>
+									<Typography variant='h4'>{albumArtist.data.name}</Typography>
+
+								</Button>
+							</Link>
 						</Grid>
 					}
 					<Grid item>

--- a/front/src/pages/releases/[slugOrId].tsx
+++ b/front/src/pages/releases/[slugOrId].tsx
@@ -156,7 +156,8 @@ const ReleasePage = (
 			setTracklist(discMap);
 		}
 	}, [tracklist.data]);
-	if (!release.data || !albumArtist) {
+	// eslint-disable-next-line no-extra-parens
+	if (!release.data || (artistId && !albumArtist.data)) {
 		return <WideLoadingComponent/>;
 	}
 	return <Box>

--- a/front/src/pages/settings/[[...panel]].tsx
+++ b/front/src/pages/settings/[[...panel]].tsx
@@ -43,8 +43,6 @@ const SettingsPage = (props: InferSSRProps<typeof getServerSideProps>) => {
 		<Tabs
 			value={panel}
 			onChange={(__, panelName) => setPanel(panelName)}
-			indicatorColor='secondary'
-			textColor='secondary'
 			centered
 		>
 			{AvailablePanels.map((panelName, index) =>

--- a/front/src/theme.ts
+++ b/front/src/theme.ts
@@ -4,9 +4,7 @@ export default responsiveFontSizes(createTheme({
 	palette: {
 		mode: 'dark',
 		primary: {
-			main: "#242120",
-			light: "#676767",
-			contrastText: "#FFFFFF"
+			main: "#ffffff"
 		},
 		secondary: {
 			main: "#ffffff"
@@ -18,7 +16,7 @@ export default responsiveFontSizes(createTheme({
 		text: {
 			primary: "#FFFFFF",
 			secondary: '#FFFFFF'
-		}
+		},
 	},
 	shape: {
 		borderRadius: '0.5rem' as unknown as number

--- a/src/album/album.controller.ts
+++ b/src/album/album.controller.ts
@@ -186,9 +186,9 @@ export default class AlbumController {
 				.filter((track, index, array) => index == array.indexOf(track))
 				.sort((track1, track2) => {
 					if (track1.discIndex != track2.discIndex) {
-						return (track1.discIndex ?? -1) - (track2.discIndex ?? -1);
+						return (track1.discIndex ?? 0) - (track2.discIndex ?? 0);
 					}
-					return (track1.trackIndex ?? -1) - (track2.trackIndex ?? -1);
+					return (track1.trackIndex ?? 0) - (track2.trackIndex ?? 0);
 				})
 				.filter((track, index, array) => array.findIndex(
 					(otherTrack) => otherTrack.songId == track.songId

--- a/src/album/album.controller.ts
+++ b/src/album/album.controller.ts
@@ -13,14 +13,12 @@ import PaginatedResponse from 'src/pagination/models/paginated-response';
 import TrackService from 'src/track/track.service';
 import TrackQueryParameters from 'src/track/models/track.query-parameters';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { TrackType } from '@prisma/client';
 import ReassignAlbumDTO from './models/reassign-album.dto';
 import GenreService from "../genre/genre.service";
-import { Genre } from "src/prisma/models";
+import { Genre, Track } from "src/prisma/models";
 import { AlbumResponse } from './models/album.response';
 import { ApiPaginatedResponse } from 'src/pagination/paginated-response.decorator';
 import { ReleaseResponse } from 'src/release/models/release.response';
-import { TrackResponse } from 'src/track/models/track.response';
 import { PaginationQuery } from 'src/pagination/pagination-query.decorator';
 import { IdentifierParam } from 'src/identifier/identifier-param.decorator';
 import { ApiRelationInclude } from 'src/relation-include/relation-include-route.decorator';
@@ -166,37 +164,39 @@ export default class AlbumController {
 	}
 
 	@ApiOperation({
-		summary: 'Get all the video tracks from an album'
+		summary: 'Get all the video tracks from an album',
+		description: "Return all video tracks of songs in album, so it might include tracks that are not in the album's tracklist"
 	})
-	@ApiPaginatedResponse(TrackResponse)
 	@Get(':idOrSlug/videos')
 	async getAlbumVideos(
-		@PaginationQuery()
-		paginationParameters: PaginationParameters,
 		@RelationIncludeQuery(TrackQueryParameters.AvailableAtomicIncludes)
 		include: TrackQueryParameters.RelationInclude,
-		@SortingQuery(TrackQueryParameters.SortingKeys)
-		sortingParameter: TrackQueryParameters.SortingParameter,
 		@IdentifierParam(ParseAlbumIdentifierPipe)
-		where: AlbumQueryParameters.WhereInput,
-		@Req() request: Request
-	) {
-		const videoTracks = await this.trackService.getMany(
-			{ byAlbum: where, type: TrackType.Video },
-			paginationParameters,
-			include,
-			sortingParameter,
+		where: AlbumQueryParameters.WhereInput
+	): Promise<Track[]> {
+		const albumReleases = await this.releaseService.getAlbumReleases(
+			where, { }, { tracks: true }
 		);
 
-		if (videoTracks.length == 0) {
-			await this.albumService.throwIfNotFound(where);
-		}
-		return PaginatedResponse.awaiting(
-			videoTracks.map(
-				(videoTrack) => this.trackService.buildResponse(videoTrack)
-			),
-			request
-		);
+		return Promise.all(
+			albumReleases
+				.map((release) => release.tracks)
+				.flat()
+				.filter((track, index, array) => index == array.indexOf(track))
+				.sort((track1, track2) => {
+					if (track1.discIndex != track2.discIndex) {
+						return (track1.discIndex ?? -1) - (track2.discIndex ?? -1);
+					}
+					return (track1.trackIndex ?? -1) - (track2.trackIndex ?? -1);
+				})
+				.filter((track, index, array) => array.findIndex(
+					(otherTrack) => otherTrack.songId == track.songId
+				) == index)
+				.map((track) => this.trackService.getMany({
+					type: 'Video',
+					bySong: { byId: { id: track.songId } },
+				}, { take: 1 }, include))
+		).then((tracks) => tracks.flat());
 	}
 
 	@ApiOperation({

--- a/src/exceptions/not-found.exception.ts
+++ b/src/exceptions/not-found.exception.ts
@@ -11,7 +11,8 @@ export default class NotFoundExceptionFilter implements ExceptionFilter {
 		response
 			.status(HttpStatus.NOT_FOUND)
 			.json({
-				error: "Route not found."
+				statusCode: HttpStatus.NOT_FOUND,
+				message: "Route not found."
 			});
 	}
 }

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -213,7 +213,6 @@ export default class FileService extends RepositoryService<
 		if (this.fileManagerService.fileExists(fullFilePath) == false) {
 			throw new SourceFileNotFoundExceptions(file.path);
 		}
-		res.status(HttpStatus.PARTIAL_CONTENT);
 		res.set({
 			'Content-Disposition': `attachment; filename="${path.basename(file.path)}"`,
 			'Content-Type': mime.getType(fullFilePath) ?? 'application/octet-stream',
@@ -223,6 +222,7 @@ export default class FileService extends RepositoryService<
 		let requestedEndByte: number | undefined = undefined;
 
 		if (rangeHeader) {
+			res.status(HttpStatus.PARTIAL_CONTENT);
 			// eslint-disable-next-line no-useless-escape
 			const bytes = /^bytes\=(\d+)\-(\d+)?$/g.exec(rangeHeader);
 

--- a/src/user/models/create-user.dto.ts
+++ b/src/user/models/create-user.dto.ts
@@ -1,7 +1,7 @@
-import { ApiProperty, OmitType } from "@nestjs/swagger";
+import { ApiProperty, PickType } from "@nestjs/swagger";
 import { User } from "src/prisma/models";
 
-export default class UserCreateDTO extends OmitType(User, ['id', 'enabled']) {
+export default class UserCreateDTO extends PickType(User, ['name', 'password']) {
 	@ApiProperty({
 		required: true,
 		description: "The user's username. Must be at least 4 characters long, composed of letters, digits, dash and underscore"

--- a/src/user/models/user.query-params.ts
+++ b/src/user/models/user.query-params.ts
@@ -6,9 +6,9 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 namespace UserQueryParameters {
 
 	/**
-	 * Paramters to create a user
+	 * Parameeters to create a user
 	 */
-	export type CreateInput = Omit<User, 'id' | 'enabled'> & Partial<Pick<User, 'enabled'>>;
+	export type CreateInput = Omit<User, 'id' | 'enabled' | 'admin'> & Partial<Pick<User, 'enabled' | 'admin'>>;
 
 	/**
 	 * Parameters to find one users


### PR DESCRIPTION
Multiple Quick fixes and improvements:

- Closes #338
- Release Page: Artist Title is a link
- Fix Theme to avoid having to set text color for transparent buttons
- Release Page: Avoid layout shift on artist load
- Rework of the /albums/:id/videos route to have a better / smarter selection
- Release Page: Use rework of /albums/:id/video instead of multiple queries
- Update 404 error response to match the other exceptions/error messages
- Library Settings Page: Fix icon alignment on narrow view ports
- User Creation Route: Remove 'admin' field from DTO