### PR TITLE
Metadata Parsing: Fix Album Date update condition

### DIFF
--- a/front/src/pages/releases/[slugOrId].tsx
+++ b/front/src/pages/releases/[slugOrId].tsx
@@ -177,7 +177,9 @@ const ReleasePage = (
 					}
 					<Grid item>
 						<Typography fontWeight='light'>
-							{release.data!.album.releaseDate && `${new Date(release.data!.album.releaseDate!).getFullYear()} - `}{formatDuration(totalDuration ?? undefined)}
+							{(release.data.releaseDate || release.data.album.releaseDate) &&
+								`${new Date(release.data.releaseDate ?? release.data.album.releaseDate!).getFullYear()} - `}
+							{formatDuration(totalDuration ?? undefined)}
 						</Typography>
 					</Grid>
 				</Grid>

--- a/server/src/metadata/metadata.service.ts
+++ b/server/src/metadata/metadata.service.ts
@@ -99,10 +99,14 @@ export default class MetadataService {
 			song: { id: song.id },
 		};
 
-		if (release.releaseDate !== null &&
+		/**
+		 * If the newly registered release is 'older' that the known album
+		 * Or if the album did not have a date, update album's date
+		 */
+		if ((release.releaseDate !== null &&
 			release.album.releaseDate !== null &&
-			release.album.releaseDate > release.releaseDate ||
-			release.releaseDate !== undefined) {
+			release.album.releaseDate > release.releaseDate) ||
+			(release.releaseDate && !release.album.releaseDate)) {
 			release.album.releaseDate = release.releaseDate;
 		}
 		if (albumArtist === undefined && release.album.type == AlbumType.StudioRecording) {


### PR DESCRIPTION
On file parsing, if the release was more recent that the album, a wrong condition would always set the album's date as the release's date