### PR TITLE
Settings validation: Use 'class-validator'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ./server/*.lock ./
 RUN yarn
 COPY ./server/src ./src
 COPY ./server/prisma/ ./prisma
-RUN yarn run prisma generate
+RUN yarn run prebuild
 RUN yarn run build
 
 

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
   "license": "GNU GENERAL PUBLIC LICENSE v3",
   "scripts": {
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "prebuild": "yarn run prisma generate",
     "build": "nest build",
     "start": "nest start",
     "start:dev": "NODE_ENV=development nest start --watch",

--- a/server/src/settings/models/settings.ts
+++ b/server/src/settings/models/settings.ts
@@ -1,4 +1,10 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import {
+	ArrayNotEmpty,
+	IsDefined,
+	IsIn, IsString, ValidateNested
+} from "class-validator";
 
 export const metadataSourceValue = ["path", "embedded"] as const;
 export const metadataOrderValue = ["only", "preferred"] as const;
@@ -8,12 +14,14 @@ class MetadataSettings {
 	 * Use the path or the embedded metadata as main metadata source
 	 */
 	@ApiProperty({ enum: metadataSourceValue })
+	@IsIn(metadataSourceValue)
 	source: typeof metadataSourceValue[number];
 
 	/**
 	 * Exclude the other source, or use is as a fallback
 	 */
 	@ApiProperty({ enum: metadataOrderValue })
+	@IsIn(metadataOrderValue)
 	order: typeof metadataOrderValue[number];
 }
 /**
@@ -24,18 +32,22 @@ export default class Settings {
 	 * The folder where `settings.json` and metadata are stored
 	 */
 	@ApiProperty()
+	@IsString()
 	meeloFolder: string;
 
 	/**
 	 * The base folder where every libraries must be located
 	 */
 	@ApiProperty()
+	@IsString()
 	dataFolder: string;
 
 	/**
 	 * Array of RegExp string, used to match track files
 	 */
 	@ApiProperty()
+	@IsString({ each: true })
+	@ArrayNotEmpty()
 	trackRegex: string[];
 
 	/**
@@ -44,5 +56,8 @@ export default class Settings {
 	@ApiProperty({
 		type: MetadataSettings
 	})
+	@Type(() => MetadataSettings)
+	@ValidateNested()
+	@IsDefined()
 	metadata: MetadataSettings;
 }

--- a/server/src/settings/settings.exception.ts
+++ b/server/src/settings/settings.exception.ts
@@ -13,8 +13,8 @@ export class SettingsFileNotFoundException extends NotFoundException {
 }
 
 export class InvalidSettingsFileException extends InvalidRequestException {
-	constructor() {
-		super(`Invalid Settings File`);
+	constructor(validationError?: string) {
+		super(`Invalid Settings File${validationError ? `: ${validationError}` : ''}`);
 	}
 }
 
@@ -24,8 +24,3 @@ export class MissingSettingsException extends InvalidRequestException {
 	}
 }
 
-export class InvalidSettingsTypeException extends InvalidRequestException {
-	constructor(fieldName: string, actualType: string) {
-		super(`Settings File: Invalid field '${fieldName}' type: ${actualType}`);
-	}
-}

--- a/server/src/settings/settings.service.spec.ts
+++ b/server/src/settings/settings.service.spec.ts
@@ -1,7 +1,6 @@
 import SettingsService from './settings.service';
 import * as fs from 'fs';
-import { InvalidSettingsFileException, InvalidSettingsTypeException, MissingSettingsException, SettingsFileNotFoundException } from './settings.exception';
-import type Settings from './models/settings';
+import { InvalidSettingsFileException, MissingSettingsException, SettingsFileNotFoundException } from './settings.exception';
 import { createTestingModule } from 'test/test-module';
 import SettingsModule from './settings.module';
 import FileManagerModule from 'src/file-manager/file-manager.module';
@@ -41,7 +40,7 @@ describe('Settings Service', () => {
 				() => fs.readFileSync('test/assets/settings-fake-regex.json').toString()
 			);
 			settingsService.loadFromFile();
-			expect(settingsService.settingsValues).toStrictEqual(<Settings>{
+			expect(settingsService.settingsValues).toMatchObject({
 				dataFolder: '/var/lib/meelo',
 				meeloFolder: 'test/assets/',
 				trackRegex: ['regex1', 'regex2'],
@@ -89,8 +88,8 @@ describe('Settings Service', () => {
 		});
 
 		it('should throw because a field data type is incorrect', async () => {
-			expectExceptionWhenParsing('settings-wrong-type.json', InvalidSettingsTypeException);
-			expectExceptionWhenParsing('settings-wrong-type-metadata-source.json', InvalidSettingsTypeException);
+			expectExceptionWhenParsing('settings-wrong-type.json', InvalidSettingsFileException);
+			expectExceptionWhenParsing('settings-wrong-type-metadata-source.json', InvalidSettingsFileException);
 		});
 	});
 })


### PR DESCRIPTION
Using class validator instead of parsing/validating 'by hand'.

This will be useful for future settings fields (eg, see #413)