### PR TITLE
Server: Compute Illustration Blurhash using aspect ratio

### DIFF
--- a/server/src/illustration/illustration.service.spec.ts
+++ b/server/src/illustration/illustration.service.spec.ts
@@ -23,6 +23,7 @@ describe("Illustration Service", () => {
 	let albumService: AlbumService;
 	const baseMetadataFolder = "test/assets/metadata";
 	let dummyRepository: TestPrismaService;
+	let getBlurhashComponentCountFromAspectRatio: IllustrationService["getBlurhashComponentCountFromAspectRatio"];
 
 	let module: TestingModule;
 	beforeAll(async () => {
@@ -51,6 +52,8 @@ describe("Illustration Service", () => {
 		releaseService = module.get<ReleaseService>(ReleaseService);
 		albumService = module.get<AlbumService>(AlbumService);
 		dummyRepository = module.get(PrismaService);
+		getBlurhashComponentCountFromAspectRatio =
+			illustrationService["getBlurhashComponentCountFromAspectRatio"];
 
 		await dummyRepository.onModuleInit();
 	});
@@ -75,7 +78,7 @@ describe("Illustration Service", () => {
 			const outPath = `${baseMetadataFolder}/illustration.jpg`;
 			it("should write data to file", async () => {
 				if (fs.existsSync(outPath)) fs.rmSync(outPath);
-				illustrationService["saveIllustration"](
+				illustrationService.saveIllustration(
 					Buffer.from("ABC"),
 					outPath,
 				);
@@ -85,7 +88,7 @@ describe("Illustration Service", () => {
 				);
 			});
 			it("should re-write data to file", async () => {
-				illustrationService["saveIllustration"](
+				illustrationService.saveIllustration(
 					Buffer.from("ABCDE"),
 					outPath,
 				);
@@ -94,6 +97,38 @@ describe("Illustration Service", () => {
 					Buffer.from("ABCDE"),
 				);
 			});
+		});
+	});
+	describe("Get Blurhash Components Count", () => {
+		it("square image", () => {
+			const [x, y] = getBlurhashComponentCountFromAspectRatio(1);
+			expect(x).toBe(4);
+			expect(y).toBe(4);
+		});
+		it("(not really) square image", () => {
+			const [x, y] = getBlurhashComponentCountFromAspectRatio(1.01);
+			expect(x).toBe(4);
+			expect(y).toBe(4);
+		});
+		it("16:9 Thumbnail", () => {
+			const [x, y] = getBlurhashComponentCountFromAspectRatio(16 / 9);
+			expect(x).toBe(4);
+			expect(y).toBe(2);
+		});
+		it("4:3 Thumbnail", () => {
+			const [x, y] = getBlurhashComponentCountFromAspectRatio(4 / 3);
+			expect(x).toBe(4);
+			expect(y).toBe(3);
+		});
+		it("DVD Artwork", () => {
+			const [x, y] = getBlurhashComponentCountFromAspectRatio(2 / 3);
+			expect(x).toBe(3);
+			expect(y).toBe(4);
+		});
+		it("2:1 Artwork", () => {
+			const [x, y] = getBlurhashComponentCountFromAspectRatio(2);
+			expect(x).toBe(4);
+			expect(y).toBe(2);
 		});
 	});
 });


### PR DESCRIPTION
Closes #667 

I though it would look somewhat better, but it does not change anything really

## Before

<img width="679" alt="Screenshot 2024-09-08 at 09 26 07" src="https://github.com/user-attachments/assets/f15c79c9-865c-4d09-8593-5b5970d2c34b">

## After

<img width="681" alt="Screenshot 2024-09-08 at 09 29 11" src="https://github.com/user-attachments/assets/5208d92d-bba9-4b0a-b3c1-f1a996a02421">
