### PR TITLE
Matcher: Provider 'features'

### DIFF
--- a/.github/actions/cache-matcher/action.yml
+++ b/.github/actions/cache-matcher/action.yml
@@ -3,10 +3,7 @@ description: 'Cache for Matcher'
 runs:
   using: "composite"
   steps:
-    - run: apk add --update --no-progress lsb-release py-pip
+    - run: apk add --update --no-progress lsb-release python3 py3-pip
       shell: sh
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
     - run: pip3 install -r matcher/requirements.txt
       shell: sh

--- a/.github/workflows/matcher.yml
+++ b/.github/workflows/matcher.yml
@@ -31,7 +31,7 @@ jobs:
   Typecheck:
     needs: changes
     if: ${{ needs.changes.outputs.matcher == 'true' && github.event_name == 'pull_request' }}
-    container: node:18-alpine3.18
+    container: python:3.14.0a2-alpine3.21
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -43,7 +43,7 @@ jobs:
           working-directory: './matcher/matcher'
   Lint:
     if: ${{ needs.changes.outputs.matcher == 'true' && github.event_name == 'pull_request' }}
-    container: node:18-alpine3.18
+    container: python:3.14.0a2-alpine3.21
     runs-on: ubuntu-latest
     needs: [ Typecheck ]
     steps:
@@ -56,7 +56,7 @@ jobs:
   Tests:
     runs-on: ubuntu-latest
     needs: [ Typecheck ]
-    container: node:18-alpine3.18
+    container: python:3.14.0a2-alpine3.21
     if: ${{ needs.changes.outputs.matcher == 'true' && always() }}
     env:
       GENIUS_ACCESS_TOKEN: "${{ secrets.GENIUS_ACCESS_TOKEN }}"

--- a/matcher/matcher/bootstrap.py
+++ b/matcher/matcher/bootstrap.py
@@ -5,7 +5,6 @@ from matcher.context import Context
 from matcher.providers.boilerplate import BaseProviderBoilerplate
 from matcher.settings import Settings
 from matcher.models.api.provider import Provider as ProviderApiModel
-from .providers.base import BaseProvider
 from .providers.factory import ProviderFactory
 from .settings import BaseProviderSettings
 

--- a/matcher/matcher/bootstrap.py
+++ b/matcher/matcher/bootstrap.py
@@ -2,6 +2,7 @@ import logging
 from typing import List
 from matcher.api import API
 from matcher.context import Context
+from matcher.providers.boilerplate import BaseProviderBoilerplate
 from matcher.settings import Settings
 from matcher.models.api.provider import Provider as ProviderApiModel
 from .providers.base import BaseProvider
@@ -58,7 +59,7 @@ def push_missing_providers(
 # Builds provider instances from .providers using their settings
 def build_provider_models(
     api_models: List[ProviderApiModel], provider_settings: List[BaseProviderSettings]
-) -> List[BaseProvider]:
+) -> List[BaseProviderBoilerplate]:
     providers = []
     for provider_setting in provider_settings:
         api_model = [

--- a/matcher/matcher/context.py
+++ b/matcher/matcher/context.py
@@ -1,17 +1,17 @@
 from dataclasses import dataclass
 from typing import List, TypeVar, Type
-from matcher.providers.base import BaseProvider
+from matcher.providers.boilerplate import BaseProviderBoilerplate
 from .api import API
 from .settings import Settings
 
-T = TypeVar("T", bound=BaseProvider)
+T = TypeVar("T", bound=BaseProviderBoilerplate)
 
 
 @dataclass
 class _InternalContext:
     client: API
     settings: Settings
-    providers: List[BaseProvider]
+    providers: List[BaseProviderBoilerplate]
 
     def get_provider(self, cl: Type[T]) -> T | None:
         for provider in self.providers:
@@ -24,7 +24,9 @@ class Context:
     _instance: _InternalContext | None
 
     @classmethod
-    def init(cls, client: API, settings: Settings, providers: List[BaseProvider]):
+    def init(
+        cls, client: API, settings: Settings, providers: List[BaseProviderBoilerplate]
+    ):
         cls._instance = _InternalContext(client, settings, providers)
 
     @classmethod

--- a/matcher/matcher/matcher/album.py
+++ b/matcher/matcher/matcher/album.py
@@ -78,15 +78,13 @@ def match_album(
         if not album:
             continue
         if not rating:
-            rating = provider.get_album_rating(album, source.url)
+            rating = provider.get_album_rating(album)
         if not description:
-            description = provider.get_album_description(album, source.url)
+            description = provider.get_album_description(album)
         if not release_date:
-            release_date = provider.get_album_release_date(album, source.url)
+            release_date = provider.get_album_release_date(album)
         genres = genres + [
-            g
-            for g in provider.get_album_genres(album, source.url) or []
-            if g not in genres
+            g for g in provider.get_album_genres(album) or [] if g not in genres
         ]
     return (
         ExternalMetadataDto(

--- a/matcher/matcher/matcher/artist.py
+++ b/matcher/matcher/matcher/artist.py
@@ -67,11 +67,9 @@ def match_artist(
         if not artist:
             continue
         if not description:
-            description = provider.get_artist_description(artist, source.url)
+            description = provider.get_artist_description(artist)
         if not artist_illustration_url:
-            artist_illustration_url = provider.get_artist_illustration_url(
-                artist, source.url
-            )
+            artist_illustration_url = provider.get_artist_illustration_url(artist)
     return (
         ExternalMetadataDto(
             description,

--- a/matcher/matcher/matcher/common.py
+++ b/matcher/matcher/matcher/common.py
@@ -1,4 +1,5 @@
 from matcher.models.api.dto import ExternalMetadataSourceDto
+from matcher.providers.boilerplate import BaseProviderBoilerplate
 from ..context import Context
 from typing import Any, Callable, List
 from matcher.providers.base import BaseProvider
@@ -13,9 +14,9 @@ def get_provider_from_external_source(dto: ExternalMetadataSourceDto):
 
 def get_sources_from_wikidata(
     wikidata_id: str,
-    missing_providers: List[BaseProvider],
-    get_wikidata_relation_key: Callable[[BaseProvider], str | None],
-    get_resource_url_from_id: Callable[[BaseProvider, str], str | None],
+    missing_providers: List[BaseProviderBoilerplate],
+    get_wikidata_relation_key: Callable[[BaseProviderBoilerplate], str | None],
+    get_resource_url_from_id: Callable[[BaseProviderBoilerplate, str], str | None],
 ) -> List[ExternalMetadataSourceDto]:
     wikidata_provider = WikidataProvider()
     wikidata_rels = wikidata_provider.get_resource_relations(wikidata_id)
@@ -62,9 +63,9 @@ def get_sources_from_wikidata(
 
 
 def get_sources_from_musicbrainz(
-    mb_search_resource: Callable[[BaseProvider], Any],
-    mb_get_resource: Callable[[BaseProvider, str], Any],
-    mb_get_url_from_id: Callable[[BaseProvider, str], str | None],
+    mb_search_resource: Callable[[BaseProviderBoilerplate], Any],
+    mb_get_resource: Callable[[BaseProviderBoilerplate, str], Any],
+    mb_get_url_from_id: Callable[[BaseProviderBoilerplate, str], str | None],
 ) -> tuple[str | None, List[ExternalMetadataSourceDto]]:
     context = Context.get()
     mb_provider = context.get_provider(MusicBrainzProvider)

--- a/matcher/matcher/matcher/common.py
+++ b/matcher/matcher/matcher/common.py
@@ -2,7 +2,6 @@ from matcher.models.api.dto import ExternalMetadataSourceDto
 from matcher.providers.boilerplate import BaseProviderBoilerplate
 from ..context import Context
 from typing import Any, Callable, List
-from matcher.providers.base import BaseProvider
 from ..providers.wikidata import WikidataProvider
 from ..providers.musicbrainz import MusicBrainzProvider
 from ..providers.wikipedia import WikipediaProvider

--- a/matcher/matcher/providers/allmusic.py
+++ b/matcher/matcher/providers/allmusic.py
@@ -3,19 +3,16 @@ import datetime
 from typing import Any, List
 import json
 import requests
-from .base import ArtistSearchResult, BaseProvider, AlbumSearchResult
-from ..models.api.provider import Provider as ApiProviderEntry
+
+from matcher.providers.boilerplate import BaseProviderBoilerplate
+from .domain import ArtistSearchResult, AlbumSearchResult
 from ..settings import AllMusicSettings
 from datetime import date
 from bs4 import BeautifulSoup, Tag
 
 
 @dataclass
-class AllMusicProvider(BaseProvider):
-    api_model: ApiProviderEntry
-    settings: AllMusicSettings
-    pass
-
+class AllMusicProvider(BaseProviderBoilerplate[AllMusicSettings]):
     def get_musicbrainz_relation_key(self) -> str | None:
         return "allmusic"
 

--- a/matcher/matcher/providers/allmusic.py
+++ b/matcher/matcher/providers/allmusic.py
@@ -1,55 +1,54 @@
 from dataclasses import dataclass
 import datetime
-from typing import Any, List
+from typing import Any
 import json
 import requests
 
 from matcher.providers.boilerplate import BaseProviderBoilerplate
-from .domain import ArtistSearchResult, AlbumSearchResult
 from ..settings import AllMusicSettings
+from .features import (
+    GetAlbumFeature,
+    GetAlbumIdFromUrlFeature,
+    GetAlbumRatingFeature,
+    GetAlbumReleaseDateFeature,
+    GetAlbumUrlFromIdFeature,
+    GetArtistUrlFromIdFeature,
+    GetMusicBrainzRelationKeyFeature,
+    GetWikidataAlbumRelationKeyFeature,
+    GetWikidataArtistRelationKeyFeature,
+)
 from datetime import date
 from bs4 import BeautifulSoup, Tag
 
 
 @dataclass
 class AllMusicProvider(BaseProviderBoilerplate[AllMusicSettings]):
-    def get_musicbrainz_relation_key(self) -> str | None:
-        return "allmusic"
-
-    def get_artist_url_from_id(self, artist_id: str) -> str | None:
-        return f"https://www.allmusic.com/artist/{artist_id}"
-
-    def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
-        pass
-
-    def get_artist_id_from_url(self, artist_url) -> str | None:
-        pass
-
-    def get_artist(self, artist_id: str) -> Any | None:
-        return None
-
-    def get_artist_description(self, artist: Any, artist_url: str) -> str | None:
-        return None
-
-    def get_artist_illustration_url(self, artist: Any, artist_url: str) -> str | None:
-        return None
-
-    def get_wikidata_artist_relation_key(self) -> str | None:
-        return "P1728"
+    def __post_init__(self):
+        self.features = [
+            GetMusicBrainzRelationKeyFeature(lambda: "allmusic"),
+            GetArtistUrlFromIdFeature(
+                lambda artist_id: f"https://www.allmusic.com/artist/{artist_id}"
+            ),
+            GetWikidataArtistRelationKeyFeature(lambda: "P1728"),
+            GetWikidataAlbumRelationKeyFeature(lambda: "P1729"),
+            GetAlbumUrlFromIdFeature(
+                lambda album_id: f"https://www.allmusic.com/album/{album_id}"
+            ),
+            GetAlbumIdFromUrlFeature(
+                lambda album_url: album_url.replace(
+                    "https://www.allmusic.com/album/", ""
+                )
+            ),
+            GetAlbumFeature(lambda album_id: self._get_album(album_id)),
+            GetAlbumRatingFeature(lambda album: self._get_album_rating(album)),
+            GetAlbumReleaseDateFeature(
+                lambda album: self._get_album_release_date(album)
+            ),
+        ]
 
     # Album
-    def search_album(
-        self, album_name: str, artist_name: str | None
-    ) -> AlbumSearchResult | None:
-        pass
 
-    def get_album_url_from_id(self, album_id: str) -> str | None:
-        return f"https://www.allmusic.com/album/{album_id}"
-
-    def get_album_id_from_url(self, album_url) -> str | None:
-        return album_url.replace("https://www.allmusic.com/album/", "")
-
-    def get_album(self, album_id: str) -> Any | None:
+    def _get_album(self, album_id: str) -> Any | None:
         try:
             html = requests.get(
                 str(self.get_album_url_from_id(album_id)),
@@ -60,10 +59,7 @@ class AllMusicProvider(BaseProviderBoilerplate[AllMusicSettings]):
         except Exception:
             pass
 
-    def get_album_description(self, album: Any, album_url: str) -> str | None:
-        pass
-
-    def get_album_rating(self, album: Any, album_url: str) -> int | None:
+    def _get_album_rating(self, album: Any) -> int | None:
         tag: Tag = album
         try:
             div = tag.find("div", attrs={"title": "AllMusic Rating"})
@@ -84,7 +80,7 @@ class AllMusicProvider(BaseProviderBoilerplate[AllMusicSettings]):
         except Exception:
             pass
 
-    def get_album_release_date(self, album: Any, album_url: str) -> date | None:
+    def _get_album_release_date(self, album: Any) -> date | None:
         try:
             raw_json = album.find("script", attrs={"type": "application/ld+json"}).text
             json_obj = json.loads(raw_json)
@@ -94,9 +90,3 @@ class AllMusicProvider(BaseProviderBoilerplate[AllMusicSettings]):
             ).date()
         except Exception:
             pass
-
-    def get_album_genres(self, album: Any, album_url: str) -> List[str] | None:
-        pass
-
-    def get_wikidata_album_relation_key(self) -> str | None:
-        return "P1729"

--- a/matcher/matcher/providers/base.py
+++ b/matcher/matcher/providers/base.py
@@ -12,7 +12,7 @@ class BaseFeature[*Args, Res]:
     Args = TypeVarTuple("Args")
     Res = TypeVar("Res")
 
-    run: Callable[["BaseProvider", *Args], Res]
+    run: Callable[[*Args], Res]
 
 
 @dataclass

--- a/matcher/matcher/providers/base.py
+++ b/matcher/matcher/providers/base.py
@@ -1,12 +1,8 @@
-from abc import abstractmethod
-from typing import Any, TypeVar, Type, TypeVarTuple, Callable
-
+from typing import TypeVar, Type, TypeVarTuple, Callable
 from matcher.settings import BaseProviderSettings
-from .domain import AlbumSearchResult, ArtistSearchResult
 from ..models.api.provider import Provider as ApiProviderEntry
 from typing import List
 from dataclasses import dataclass, field
-from datetime import date
 
 Settings = TypeVar("Settings", bound=BaseProviderSettings, default=BaseProviderSettings)
 
@@ -34,78 +30,3 @@ class BaseProvider[Settings]:
             return [f for f in self.features if isinstance(f, t)][0]
         except Exception:
             pass
-
-    @abstractmethod
-    def get_musicbrainz_relation_key(self) -> str | None:
-        pass
-
-    def is_musicbrainz_relation(self, rel: Any) -> bool | None:
-        pass
-
-    # Artist
-    @abstractmethod
-    def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
-        pass
-
-    @abstractmethod
-    def get_artist_url_from_id(self, artist_id: str) -> str | None:
-        pass
-
-    @abstractmethod
-    def get_artist_id_from_url(self, artist_url) -> str | None:
-        pass
-
-    @abstractmethod
-    def get_artist(self, artist_id: str) -> Any | None:
-        pass
-
-    @abstractmethod
-    def get_artist_description(self, artist: Any, artist_url: str) -> str | None:
-        pass
-
-    @abstractmethod
-    def get_artist_illustration_url(self, artist: Any, artist_url: str) -> str | None:
-        pass
-
-    @abstractmethod
-    def get_wikidata_artist_relation_key(self) -> str | None:
-        pass
-
-    # Album
-    @abstractmethod
-    def search_album(
-        self, album_name: str, artist_name: str | None
-    ) -> AlbumSearchResult | None:
-        pass
-
-    @abstractmethod
-    def get_album_url_from_id(self, album_id: str) -> str | None:
-        pass
-
-    @abstractmethod
-    def get_album_id_from_url(self, album_url) -> str | None:
-        pass
-
-    @abstractmethod
-    def get_album(self, album_id: str) -> Any | None:
-        pass
-
-    @abstractmethod
-    def get_album_description(self, album: Any, album_url: str) -> str | None:
-        pass
-
-    @abstractmethod
-    def get_album_rating(self, album: Any, album_url: str) -> int | None:
-        pass
-
-    @abstractmethod
-    def get_album_genres(self, album: Any, album_url: str) -> List[str] | None:
-        pass
-
-    @abstractmethod
-    def get_album_release_date(self, album: Any, album_url: str) -> date | None:
-        pass
-
-    @abstractmethod
-    def get_wikidata_album_relation_key(self) -> str | None:
-        pass

--- a/matcher/matcher/providers/boilerplate.py
+++ b/matcher/matcher/providers/boilerplate.py
@@ -1,0 +1,113 @@
+from matcher.providers.base import BaseProvider
+from datetime import date
+from .features import (
+    GetAlbumDescriptionFeature,
+    GetAlbumFeature,
+    GetAlbumGenresFeature,
+    GetAlbumIdFromUrlFeature,
+    GetAlbumRatingFeature,
+    GetAlbumReleaseDateFeature,
+    GetAlbumUrlFromIdFeature,
+    GetArtistDescriptionFeature,
+    GetArtistFeature,
+    GetArtistIdFromUrlFeature,
+    GetArtistIllustrationUrlFeature,
+    GetArtistUrlFromIdFeature,
+    GetMusicBrainzRelationKeyFeature,
+    GetWikidataAlbumRelationKeyFeature,
+    GetWikidataArtistRelationKeyFeature,
+    IsMusicBrainzRelationFeature,
+    SearchAlbumFeature,
+    SearchArtistFeature,
+)
+from .domain import AlbumSearchResult, ArtistSearchResult
+from typing import Any, List
+
+
+# A = ParamSpec("A")
+# R = TypeVar("R")
+# F = TypeVar("F", bound=BaseFeature, covariant=True)
+
+
+class BaseProviderBoilerplate[S](BaseProvider[S]):
+    # def _run_feature_if_exists[A, R, F: BaseFeature[A, R]](
+    #     self, featureClass: Type[F]
+    # ) -> R | None:
+    #     f = self.get_feature(featureClass)
+    #     return f.run()
+
+    def get_musicbrainz_relation_key(self) -> str | None:
+        f = self.get_feature(GetMusicBrainzRelationKeyFeature)
+        return f.run(self) if f else None
+
+    def is_musicbrainz_relation(self, rel: Any) -> bool | None:
+        f = self.get_feature(IsMusicBrainzRelationFeature)
+        return f.run(self, rel) if f else None
+
+    # Artist
+    def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
+        f = self.get_feature(SearchArtistFeature)
+        return f.run(self, artist_name) if f else None
+
+    def get_artist_url_from_id(self, artist_id: str) -> str | None:
+        f = self.get_feature(GetArtistUrlFromIdFeature)
+        return f.run(self, artist_id) if f else None
+
+    def get_artist_id_from_url(self, artist_url) -> str | None:
+        f = self.get_feature(GetArtistIdFromUrlFeature)
+        return f.run(self, artist_url) if f else None
+
+    def get_artist(self, artist_id: str) -> Any | None:
+        f = self.get_feature(GetArtistFeature)
+        return f.run(self, artist_id) if f else None
+
+    def get_artist_description(self, artist: Any) -> str | None:
+        f = self.get_feature(GetArtistDescriptionFeature)
+        return f.run(self, artist) if f else None
+
+    def get_artist_illustration_url(self, artist: Any) -> str | None:
+        f = self.get_feature(GetArtistIllustrationUrlFeature)
+        return f.run(self, artist) if f else None
+
+    def get_wikidata_artist_relation_key(self) -> str | None:
+        f = self.get_feature(GetWikidataArtistRelationKeyFeature)
+        return f.run(self) if f else None
+
+    # Album
+    def search_album(
+        self, album_name: str, artist_name: str | None
+    ) -> AlbumSearchResult | None:
+        f = self.get_feature(SearchAlbumFeature)
+        return f.run(self, album_name, artist_name) if f else None
+
+    def get_album_url_from_id(self, album_id: str) -> str | None:
+        f = self.get_feature(GetAlbumUrlFromIdFeature)
+        return f.run(self, album_id) if f else None
+
+    def get_album_id_from_url(self, album_url) -> str | None:
+        f = self.get_feature(GetAlbumIdFromUrlFeature)
+        return f.run(self, album_url) if f else None
+
+    def get_album(self, album_id: str) -> Any | None:
+        f = self.get_feature(GetAlbumFeature)
+        return f.run(self, album_id) if f else None
+
+    def get_album_description(self, album: Any) -> str | None:
+        f = self.get_feature(GetAlbumDescriptionFeature)
+        return f.run(self, album) if f else None
+
+    def get_album_rating(self, album: Any) -> int | None:
+        f = self.get_feature(GetAlbumRatingFeature)
+        return f.run(self, album) if f else None
+
+    def get_album_genres(self, album: Any) -> List[str] | None:
+        f = self.get_feature(GetAlbumGenresFeature)
+        return f.run(self, album) if f else None
+
+    def get_album_release_date(self, album: Any) -> date | None:
+        f = self.get_feature(GetAlbumReleaseDateFeature)
+        return f.run(self, album) if f else None
+
+    def get_wikidata_album_relation_key(self) -> str | None:
+        f = self.get_feature(GetWikidataAlbumRelationKeyFeature)
+        return f.run(self) if f else None

--- a/matcher/matcher/providers/boilerplate.py
+++ b/matcher/matcher/providers/boilerplate.py
@@ -38,76 +38,76 @@ class BaseProviderBoilerplate[S](BaseProvider[S]):
 
     def get_musicbrainz_relation_key(self) -> str | None:
         f = self.get_feature(GetMusicBrainzRelationKeyFeature)
-        return f.run(self) if f else None
+        return f.run() if f else None
 
     def is_musicbrainz_relation(self, rel: Any) -> bool | None:
         f = self.get_feature(IsMusicBrainzRelationFeature)
-        return f.run(self, rel) if f else None
+        return f.run(rel) if f else None
 
     # Artist
     def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
         f = self.get_feature(SearchArtistFeature)
-        return f.run(self, artist_name) if f else None
+        return f.run(artist_name) if f else None
 
     def get_artist_url_from_id(self, artist_id: str) -> str | None:
         f = self.get_feature(GetArtistUrlFromIdFeature)
-        return f.run(self, artist_id) if f else None
+        return f.run(artist_id) if f else None
 
     def get_artist_id_from_url(self, artist_url) -> str | None:
         f = self.get_feature(GetArtistIdFromUrlFeature)
-        return f.run(self, artist_url) if f else None
+        return f.run(artist_url) if f else None
 
     def get_artist(self, artist_id: str) -> Any | None:
         f = self.get_feature(GetArtistFeature)
-        return f.run(self, artist_id) if f else None
+        return f.run(artist_id) if f else None
 
     def get_artist_description(self, artist: Any) -> str | None:
         f = self.get_feature(GetArtistDescriptionFeature)
-        return f.run(self, artist) if f else None
+        return f.run(artist) if f else None
 
     def get_artist_illustration_url(self, artist: Any) -> str | None:
         f = self.get_feature(GetArtistIllustrationUrlFeature)
-        return f.run(self, artist) if f else None
+        return f.run(artist) if f else None
 
     def get_wikidata_artist_relation_key(self) -> str | None:
         f = self.get_feature(GetWikidataArtistRelationKeyFeature)
-        return f.run(self) if f else None
+        return f.run() if f else None
 
     # Album
     def search_album(
         self, album_name: str, artist_name: str | None
     ) -> AlbumSearchResult | None:
         f = self.get_feature(SearchAlbumFeature)
-        return f.run(self, album_name, artist_name) if f else None
+        return f.run(album_name, artist_name) if f else None
 
     def get_album_url_from_id(self, album_id: str) -> str | None:
         f = self.get_feature(GetAlbumUrlFromIdFeature)
-        return f.run(self, album_id) if f else None
+        return f.run(album_id) if f else None
 
     def get_album_id_from_url(self, album_url) -> str | None:
         f = self.get_feature(GetAlbumIdFromUrlFeature)
-        return f.run(self, album_url) if f else None
+        return f.run(album_url) if f else None
 
     def get_album(self, album_id: str) -> Any | None:
         f = self.get_feature(GetAlbumFeature)
-        return f.run(self, album_id) if f else None
+        return f.run(album_id) if f else None
 
     def get_album_description(self, album: Any) -> str | None:
         f = self.get_feature(GetAlbumDescriptionFeature)
-        return f.run(self, album) if f else None
+        return f.run(album) if f else None
 
     def get_album_rating(self, album: Any) -> int | None:
         f = self.get_feature(GetAlbumRatingFeature)
-        return f.run(self, album) if f else None
+        return f.run(album) if f else None
 
     def get_album_genres(self, album: Any) -> List[str] | None:
         f = self.get_feature(GetAlbumGenresFeature)
-        return f.run(self, album) if f else None
+        return f.run(album) if f else None
 
     def get_album_release_date(self, album: Any) -> date | None:
         f = self.get_feature(GetAlbumReleaseDateFeature)
-        return f.run(self, album) if f else None
+        return f.run(album) if f else None
 
     def get_wikidata_album_relation_key(self) -> str | None:
         f = self.get_feature(GetWikidataAlbumRelationKeyFeature)
-        return f.run(self) if f else None
+        return f.run() if f else None

--- a/matcher/matcher/providers/discogs.py
+++ b/matcher/matcher/providers/discogs.py
@@ -2,21 +2,17 @@ from dataclasses import dataclass
 from typing import Any, List
 
 from matcher.utils import capitalize_all_words
-from ..models.api.provider import Provider as ApiProviderEntry
 import discogs_client.client
 import requests
-from .base import ArtistSearchResult, BaseProvider, AlbumSearchResult
+from .domain import ArtistSearchResult, AlbumSearchResult
+from .boilerplate import BaseProviderBoilerplate
 from ..settings import DiscogsSettings
 from datetime import date
 import discogs_client
 
 
 @dataclass
-class DiscogsProvider(BaseProvider):
-    api_model: ApiProviderEntry
-    settings: DiscogsSettings
-    pass
-
+class DiscogsProvider(BaseProviderBoilerplate[DiscogsSettings]):
     def _headers(self):
         return {
             "Accept-Encoding": "gzip",

--- a/matcher/matcher/providers/discogs.py
+++ b/matcher/matcher/providers/discogs.py
@@ -1,18 +1,71 @@
 from dataclasses import dataclass
 from typing import Any, List
 
+from matcher.providers.features import (
+    GetAlbumFeature,
+    GetAlbumGenresFeature,
+    GetAlbumIdFromUrlFeature,
+    GetAlbumUrlFromIdFeature,
+    GetArtistDescriptionFeature,
+    GetArtistFeature,
+    GetArtistIdFromUrlFeature,
+    GetArtistIllustrationUrlFeature,
+    GetArtistUrlFromIdFeature,
+    GetWikidataAlbumRelationKeyFeature,
+    GetWikidataArtistRelationKeyFeature,
+    SearchArtistFeature,
+    GetMusicBrainzRelationKeyFeature,
+)
 from matcher.utils import capitalize_all_words
 import discogs_client.client
 import requests
-from .domain import ArtistSearchResult, AlbumSearchResult
+from .domain import ArtistSearchResult
 from .boilerplate import BaseProviderBoilerplate
 from ..settings import DiscogsSettings
-from datetime import date
 import discogs_client
+
+# Notes:
+# - We dont get album descriptions because they are too short and/or technical
+# - Release date for albums are just years. We could get a date from the master release but shrug
+# - Searching albums is Unimplemented because need to identify singles from albums
+#   Too lazy, and anyway we propably dont need info from that provider
 
 
 @dataclass
 class DiscogsProvider(BaseProviderBoilerplate[DiscogsSettings]):
+    def __post_init__(self):
+        self.features = [
+            GetMusicBrainzRelationKeyFeature(lambda: "discogs"),
+            SearchArtistFeature(lambda artist_name: self._search_artist(artist_name)),
+            GetArtistIdFromUrlFeature(
+                lambda artist_url: artist_url.replace(
+                    "https://www.discogs.com/artist/", ""
+                )
+            ),
+            GetArtistUrlFromIdFeature(
+                lambda artist_id: "https://www.discogs.com/artist/" + str(artist_id)
+            ),
+            GetArtistFeature(lambda artist_name: self._get_artist(artist_name)),
+            GetArtistDescriptionFeature(
+                lambda artist: self._get_artist_description(artist)
+            ),
+            GetArtistIllustrationUrlFeature(
+                lambda artist: self._get_artist_illustration_url(artist)
+            ),
+            GetWikidataArtistRelationKeyFeature(lambda: "P1953"),
+            GetWikidataAlbumRelationKeyFeature(lambda: "P1954"),
+            GetAlbumUrlFromIdFeature(
+                lambda album_id: f"https://www.discogs.com/master/{album_id}"
+            ),
+            GetAlbumIdFromUrlFeature(
+                lambda album_url: album_url.replace(
+                    "https://www.discogs.com/master/", ""
+                )
+            ),
+            GetAlbumFeature(lambda album_id: self._get_album(album_id)),
+            GetAlbumGenresFeature(lambda album: self._get_album_genres(album)),
+        ]
+
     def _headers(self):
         return {
             "Accept-Encoding": "gzip",
@@ -25,7 +78,7 @@ class DiscogsProvider(BaseProviderBoilerplate[DiscogsSettings]):
             "Meelo Matcher/0.0.1", user_token=self.settings.api_key
         )
 
-    def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
+    def _search_artist(self, artist_name: str) -> ArtistSearchResult | None:
         client = self._get_client()
         try:
             return ArtistSearchResult(
@@ -34,16 +87,7 @@ class DiscogsProvider(BaseProviderBoilerplate[DiscogsSettings]):
         except Exception:
             return None
 
-    def get_musicbrainz_relation_key(self) -> str | None:
-        return "discogs"
-
-    def get_artist_id_from_url(self, artist_url) -> str | None:
-        return artist_url.replace("https://www.discogs.com/artist/", "")
-
-    def get_artist_url_from_id(self, artist_id: str) -> str | None:
-        return "https://www.discogs.com/artist/" + str(artist_id)
-
-    def get_artist(self, artist_id: str) -> Any | None:
+    def _get_artist(self, artist_id: str) -> Any | None:
         try:
             return requests.get(
                 f"https://api.discogs.com/artists/{artist_id}",
@@ -53,36 +97,21 @@ class DiscogsProvider(BaseProviderBoilerplate[DiscogsSettings]):
         except Exception:
             return None
 
-    def get_artist_description(self, artist: Any, artist_url: str) -> str | None:
+    def _get_artist_description(self, artist: Any) -> str | None:
         try:
             return artist["profile_plaintext"]
         except Exception:
             return None
 
-    def get_artist_illustration_url(self, artist: Any, artist_url: str) -> str | None:
+    def _get_artist_illustration_url(self, artist: Any) -> str | None:
         try:
             return artist["images"][0]["uri"]
         except Exception:
             return None
 
-    def get_wikidata_artist_relation_key(self) -> str | None:
-        return "P1953"
-
     # Album
-    def search_album(
-        self, album_name: str, artist_name: str | None
-    ) -> AlbumSearchResult | None:
-        # Unimplemented because need to identify singles from albums
-        # Too lazy, and anyway we propably dont need info from that provider
-        pass
 
-    def get_album_url_from_id(self, album_id: str) -> str | None:
-        return f"https://www.discogs.com/master/{album_id}"
-
-    def get_album_id_from_url(self, album_url) -> str | None:
-        return album_url.replace("https://www.discogs.com/master/", "")
-
-    def get_album(self, album_id: str) -> Any | None:
+    def _get_album(self, album_id: str) -> Any | None:
         try:
             return requests.get(
                 f"https://api.discogs.com/masters/{album_id}",
@@ -92,22 +121,8 @@ class DiscogsProvider(BaseProviderBoilerplate[DiscogsSettings]):
         except Exception:
             return None
 
-    def get_album_description(self, album: Any, album_url: str) -> str | None:
-        # Description from this provider aren't good
-        pass
-
-    def get_album_release_date(self, album: Any, album_url: str) -> date | None:
-        # It only provides a year, skip
-        pass
-
-    def get_album_rating(self, album: Any, album_url: str) -> int | None:
-        pass
-
-    def get_album_genres(self, album: Any, album_url: str) -> List[str] | None:
+    def _get_album_genres(self, album: Any) -> List[str] | None:
         try:
             return [capitalize_all_words(g) for g in album["genres"]]
         except Exception:
             pass
-
-    def get_wikidata_album_relation_key(self) -> str | None:
-        return "P1954"

--- a/matcher/matcher/providers/domain.py
+++ b/matcher/matcher/providers/domain.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from typing import TypeAlias
+
+
+@dataclass
+class ArtistSearchResult:
+    id: str
+
+
+@dataclass
+class AlbumSearchResult:
+    id: str
+
+
+ResourceUrl: TypeAlias = str
+
+ResourceName: TypeAlias = str
+
+ResourceId: TypeAlias = str

--- a/matcher/matcher/providers/factory.py
+++ b/matcher/matcher/providers/factory.py
@@ -1,6 +1,6 @@
 from typing import TypeVar, cast
 from matcher.providers.allmusic import AllMusicProvider
-from matcher.providers.base import BaseProvider
+from matcher.providers.boilerplate import BaseProviderBoilerplate
 from matcher.providers.discogs import DiscogsProvider
 from matcher.providers.genius import GeniusProvider
 from matcher.providers.metacritic import MetacriticProvider
@@ -24,7 +24,7 @@ class ProviderFactory:
     @staticmethod
     def buildProvider(
         api_model: ApiProviderEntry, settings: BaseProviderSettings
-    ) -> BaseProvider:
+    ) -> BaseProviderBoilerplate:
         match settings.name:
             case "AllMusic":
                 return AllMusicProvider(api_model, cast(AllMusicSettings, settings))

--- a/matcher/matcher/providers/features.py
+++ b/matcher/matcher/providers/features.py
@@ -1,0 +1,104 @@
+from datetime import date
+from typing import Any, List
+from matcher.providers.base import BaseFeature
+
+from matcher.providers.domain import (
+    AlbumSearchResult,
+    ResourceId,
+    ResourceUrl,
+    ResourceName,
+)
+
+
+## Common
+class GetUrlFromIdFeature(BaseFeature[ResourceId, ResourceUrl]):
+    pass
+
+
+class GetIdFromUrlFeature(BaseFeature[ResourceUrl, ResourceId]):
+    pass
+
+
+class GetWikidataRelationKeyFeature(BaseFeature[str]):
+    pass
+
+
+## Cross-relations
+class GetMusicBrainzRelationKeyFeature(BaseFeature[str]):
+    pass
+
+
+class IsMusicBrainzRelationFeature(BaseFeature[Any, bool]):
+    pass
+
+
+## Artists
+
+
+class SearchArtistFeature(BaseFeature[str, AlbumSearchResult | None]):
+    pass
+
+
+class GetArtistFeature(BaseFeature[ResourceId, Any | None]):
+    pass
+
+
+class GetArtistDescriptionFeature(BaseFeature[Any, str | None]):
+    pass
+
+
+class GetArtistIllustrationUrlFeature(BaseFeature[Any, str | None]):
+    pass
+
+
+class GetWikidataArtistRelationKeyFeature(GetWikidataRelationKeyFeature):
+    pass
+
+
+class GetArtistUrlFromIdFeature(GetUrlFromIdFeature):
+    pass
+
+
+class GetArtistIdFromUrlFeature(GetIdFromUrlFeature):
+    pass
+
+
+## Albums
+
+
+class SearchAlbumFeature(
+    BaseFeature[ResourceName, ResourceName | None, AlbumSearchResult | None]
+):
+    pass
+
+
+class GetAlbumFeature(BaseFeature[ResourceId, Any | None]):
+    pass
+
+
+class GetAlbumDescriptionFeature(BaseFeature[Any, str | None]):
+    pass
+
+
+class GetAlbumRatingFeature(BaseFeature[Any, int | None]):
+    pass
+
+
+class GetAlbumGenresFeature(BaseFeature[Any, List[str] | None]):
+    pass
+
+
+class GetAlbumWikidataRelationKeyFeature(GetWikidataRelationKeyFeature):
+    pass
+
+
+class GetAlbumReleaseDateFeature(BaseFeature[Any, date | None]):
+    pass
+
+
+class GetAlbumUrlFromIdFeature(GetUrlFromIdFeature):
+    pass
+
+
+class GetAlbumIdFromUrlFeature(GetIdFromUrlFeature):
+    pass

--- a/matcher/matcher/providers/features.py
+++ b/matcher/matcher/providers/features.py
@@ -1,9 +1,9 @@
 from datetime import date
 from typing import Any, List
 from matcher.providers.base import BaseFeature
-
 from matcher.providers.domain import (
     AlbumSearchResult,
+    ArtistSearchResult,
     ResourceId,
     ResourceUrl,
     ResourceName,
@@ -35,7 +35,7 @@ class IsMusicBrainzRelationFeature(BaseFeature[Any, bool]):
 ## Artists
 
 
-class SearchArtistFeature(BaseFeature[str, AlbumSearchResult | None]):
+class SearchArtistFeature(BaseFeature[str, ArtistSearchResult | None]):
     pass
 
 
@@ -101,4 +101,8 @@ class GetAlbumUrlFromIdFeature(GetUrlFromIdFeature):
 
 
 class GetAlbumIdFromUrlFeature(GetIdFromUrlFeature):
+    pass
+
+
+class GetWikidataAlbumRelationKeyFeature(GetWikidataRelationKeyFeature):
     pass

--- a/matcher/matcher/providers/genius.py
+++ b/matcher/matcher/providers/genius.py
@@ -1,21 +1,17 @@
 from dataclasses import dataclass
 from typing import Any, List
 import requests
-from .base import ArtistSearchResult, BaseProvider, AlbumSearchResult
+from .domain import ArtistSearchResult, AlbumSearchResult
+from .boilerplate import BaseProviderBoilerplate
 from ..settings import GeniusSettings
 from urllib.parse import urlparse
-from ..models.api.provider import Provider as ApiProviderEntry
 from datetime import date
 from ..utils import to_slug
 
 
 # Consider that the passed Ids are names, not the numeric ids
 @dataclass
-class GeniusProvider(BaseProvider):
-    api_model: ApiProviderEntry
-    settings: GeniusSettings
-    pass
-
+class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
     def _fetch(self, url: str, params={}, host="https://genius.com/api"):
         return requests.get(
             f"{host}{url}",

--- a/matcher/matcher/providers/genius.py
+++ b/matcher/matcher/providers/genius.py
@@ -1,6 +1,24 @@
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any
 import requests
+
+from matcher.providers.features import (
+    GetAlbumFeature,
+    GetAlbumIdFromUrlFeature,
+    GetAlbumReleaseDateFeature,
+    GetAlbumUrlFromIdFeature,
+    GetArtistDescriptionFeature,
+    GetArtistFeature,
+    GetArtistIdFromUrlFeature,
+    GetArtistIllustrationUrlFeature,
+    GetArtistUrlFromIdFeature,
+    GetMusicBrainzRelationKeyFeature,
+    GetWikidataAlbumRelationKeyFeature,
+    GetWikidataArtistRelationKeyFeature,
+    IsMusicBrainzRelationFeature,
+    SearchAlbumFeature,
+    SearchArtistFeature,
+)
 from .domain import ArtistSearchResult, AlbumSearchResult
 from .boilerplate import BaseProviderBoilerplate
 from ..settings import GeniusSettings
@@ -12,6 +30,46 @@ from ..utils import to_slug
 # Consider that the passed Ids are names, not the numeric ids
 @dataclass
 class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
+    def __post_init__(self):
+        self.features = [
+            GetMusicBrainzRelationKeyFeature(lambda: "genius"),
+            IsMusicBrainzRelationFeature(
+                lambda rel: rel["type"] == "lyrics"
+                and urlparse(rel["url"]["resource"]).netloc == "genius.com"
+            ),
+            SearchArtistFeature(lambda artist_name: self._search_artist(artist_name)),
+            GetArtistIdFromUrlFeature(
+                lambda artist_url: artist_url.replace("https://genius.com/artists/", "")
+            ),
+            GetArtistUrlFromIdFeature(
+                lambda artist_id: f"https://genius.com/artists/{artist_id}"
+            ),
+            GetArtistFeature(lambda artist_id: self._get_artist(artist_id)),
+            GetArtistDescriptionFeature(
+                lambda artist: self._get_artist_description(artist)
+            ),
+            GetArtistIllustrationUrlFeature(
+                lambda artist: self._get_artist_illustration_url(artist)
+            ),
+            GetWikidataArtistRelationKeyFeature(lambda: "P2373"),
+            SearchAlbumFeature(
+                lambda album_name, artist_name: self._search_album(
+                    album_name, artist_name
+                )
+            ),
+            GetAlbumUrlFromIdFeature(
+                lambda album_id: f"https://genius.com/albums/{album_id}"
+            ),
+            GetAlbumIdFromUrlFeature(
+                lambda album_url: album_url.replace("https://genius.com/albums/", "")
+            ),
+            GetAlbumFeature(lambda album: self._get_album(album)),
+            GetAlbumReleaseDateFeature(
+                lambda album: self._get_album_release_date(album)
+            ),
+            GetWikidataAlbumRelationKeyFeature(lambda: "P6217"),
+        ]
+
     def _fetch(self, url: str, params={}, host="https://genius.com/api"):
         return requests.get(
             f"{host}{url}",
@@ -24,7 +82,7 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
             },
         ).json()
 
-    def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
+    def _search_artist(self, artist_name: str) -> ArtistSearchResult | None:
         try:
             artists = self._fetch("/search/artist", {"q": artist_name})["response"][
                 "sections"
@@ -37,23 +95,7 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
         except Exception:
             return None
 
-    def get_musicbrainz_relation_key(self) -> str | None:
-        return "genius"
-
-    def is_musicbrainz_relation(self, rel: Any) -> bool | None:
-        return (
-            rel["type"] == "lyrics"
-            and urlparse(rel["url"]["resource"]).netloc == "genius.com"
-        )
-
-    def get_artist_id_from_url(self, artist_url: str) -> str | None:
-        id = artist_url.replace("https://genius.com/artists/", "")
-        return id
-
-    def get_artist_url_from_id(self, artist_id: str) -> str | None:
-        return f"https://genius.com/artists/{artist_id}"
-
-    def get_artist(self, artist_id: str) -> Any | None:
+    def _get_artist(self, artist_id: str) -> Any | None:
         try:
             artists = self._fetch("/search/artist", {"q": artist_id})["response"][
                 "sections"
@@ -71,7 +113,7 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
         except Exception:
             return None
 
-    def get_artist_description(self, artist, artist_url: str) -> str | None:
+    def _get_artist_description(self, artist) -> str | None:
         try:
             artist = self._fetch(
                 artist["api_path"], {"text_format": "plain"}, "https://api.genius.com"
@@ -83,7 +125,7 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
         except Exception:
             return None
 
-    def get_artist_illustration_url(self, artist: Any, artist_url: str) -> str | None:
+    def _get_artist_illustration_url(self, artist: Any) -> str | None:
         try:
             imageUrl = artist["image_url"]
             if "default_avatar" in imageUrl:
@@ -92,11 +134,8 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
         except Exception:
             return None
 
-    def get_wikidata_artist_relation_key(self) -> str | None:
-        return "P2373"
-
     # Album
-    def search_album(
+    def _search_album(
         self, album_name: str, artist_name: str | None
     ) -> AlbumSearchResult | None:
         artist_slug = None if not artist_name else to_slug(artist_name)
@@ -116,13 +155,7 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
         except Exception:
             return None
 
-    def get_album_url_from_id(self, album_id: str) -> str | None:
-        return f"https://genius.com/albums/{album_id}"
-
-    def get_album_id_from_url(self, album_url) -> str | None:
-        return album_url.replace("https://genius.com/albums/", "")
-
-    def get_album(self, album_id: str) -> Any | None:
+    def _get_album(self, album_id: str) -> Any | None:
         try:
             artists = self._fetch("/search/album", {"q": album_id})["response"][
                 "sections"
@@ -137,13 +170,7 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
         except Exception:
             return None
 
-    def get_album_description(self, album: Any, album_url: str) -> str | None:
-        pass
-
-    def get_album_rating(self, album: Any, album_url: str) -> int | None:
-        pass
-
-    def get_album_release_date(self, album: Any, album_url: str) -> date | None:
+    def _get_album_release_date(self, album: Any) -> date | None:
         try:
             album_release_date = album["release_date_components"]
             return date(
@@ -153,9 +180,3 @@ class GeniusProvider(BaseProviderBoilerplate[GeniusSettings]):
             )
         except Exception:
             pass
-
-    def get_album_genres(self, album: Any, album_url: str) -> List[str] | None:
-        pass
-
-    def get_wikidata_album_relation_key(self) -> str | None:
-        return "P6217"

--- a/matcher/matcher/providers/metacritic.py
+++ b/matcher/matcher/providers/metacritic.py
@@ -1,57 +1,57 @@
 from dataclasses import dataclass
-from typing import Any, List
-from matcher.providers.features import GetAlbumFeature
+from typing import Any
+from matcher.providers.boilerplate import BaseProviderBoilerplate
+from matcher.providers.features import (
+    GetAlbumFeature,
+    GetAlbumIdFromUrlFeature,
+    GetAlbumRatingFeature,
+    GetAlbumReleaseDateFeature,
+    GetAlbumUrlFromIdFeature,
+    GetArtistIdFromUrlFeature,
+    GetArtistUrlFromIdFeature,
+    GetWikidataArtistRelationKeyFeature,
+    GetWikidataAlbumRelationKeyFeature,
+    IsMusicBrainzRelationFeature,
+)
 from matcher.settings import MetacriticSettings
-from .base import ArtistSearchResult, BaseProvider, AlbumSearchResult
 import requests
 from bs4 import BeautifulSoup, Tag
 from datetime import date, datetime
 
 
 @dataclass
-class MetacriticProvider(BaseProvider[MetacriticSettings]):
+class MetacriticProvider(BaseProviderBoilerplate[MetacriticSettings]):
     def __post_init__(self):
-        self.features = []
+        self.features = [
+            IsMusicBrainzRelationFeature(
+                lambda _, rel: "metacritic" in rel["url"]["resource"]
+            ),
+            GetArtistIdFromUrlFeature(
+                lambda _, url: url.replace("https://metacritic.com/person", "")
+            ),
+            GetArtistUrlFromIdFeature(
+                lambda _,
+                artist_id: f"https://www.metacritic.com/person/{artist_id.removeprefix('person/')}"
+            ),
+            GetWikidataArtistRelationKeyFeature(lambda _: "P1712"),
+            GetAlbumUrlFromIdFeature(
+                lambda _,
+                album_id: f"https://www.metacritic.com/music/{album_id.replace('music/', '')}"
+            ),
+            GetAlbumIdFromUrlFeature(
+                lambda _, album_url: album_url.replace(
+                    "https://www.metacritic.com/music/", ""
+                )
+            ),
+            GetWikidataAlbumRelationKeyFeature(lambda _: "P1712"),
+            GetAlbumFeature(lambda _, album_id: self._get_album(album_id)),
+            GetAlbumReleaseDateFeature(
+                lambda _, album: self._get_album_release_date(album)
+            ),
+            GetAlbumRatingFeature(lambda _, album: self._get_album_rating(album)),
+        ]
 
-    def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
-        pass
-
-    def get_musicbrainz_relation_key(self) -> str | None:
-        pass
-
-    def is_musicbrainz_relation(self, rel: Any) -> bool | None:
-        return "metacritic" in rel["url"]["resource"]
-
-    def get_artist_id_from_url(self, artist_url) -> str | None:
-        return None
-
-    def get_artist_url_from_id(self, artist_id: str) -> str | None:
-        return f"https://www.metacritic.com/person/{artist_id.removeprefix('person/')}"
-
-    def get_artist(self, artist_id: str) -> Any | None:
-        return None
-
-    def get_artist_description(self, artist: Any, artist_url: str) -> str | None:
-        return None
-
-    def get_artist_illustration_url(self, artist: Any, artist_url: str) -> str | None:
-        return None
-
-    def get_wikidata_artist_relation_key(self) -> str | None:
-        return "P1712"
-
-    def search_album(
-        self, album_name: str, artist_name: str | None
-    ) -> AlbumSearchResult | None:
-        pass
-
-    def get_album_url_from_id(self, album_id: str) -> str | None:
-        return f"https://www.metacritic.com/music/{album_id.replace('music/', '')}"
-
-    def get_album_id_from_url(self, album_url) -> str | None:
-        return album_url.replace("https://www.metacritic.com/music/", "")
-
-    def get_album(self, album_id: str) -> Any | None:
+    def _get_album(self, album_id: str) -> Any | None:
         album_url = self.get_album_url_from_id(album_id)
         try:
             html = requests.get(
@@ -63,19 +63,19 @@ class MetacriticProvider(BaseProvider[MetacriticSettings]):
         except Exception:
             pass
 
-    def get_album_description(self, album: Any, album_url: str) -> str | None:
-        pass
-        # Note, MC's description are rarely of satisfactory quality/length
-        # tag: Tag = album
-        # try:
-        #     description = tag.find(
-        #         "span", attrs={"itemprop": "description"}
-        #     ).text.strip()  # pyright: ignore
-        #     return description if len(description) > 0 else None
-        # except Exception:
-        #     pass
+    # def _get_album_description(self, album: Any, album_url: str) -> str | None:
+    #     pass
+    # Note, MC's description are rarely of satisfactory quality/length
+    # tag: Tag = album
+    # try:
+    #     description = tag.find(
+    #         "span", attrs={"itemprop": "description"}
+    #     ).text.strip()  # pyright: ignore
+    #     return description if len(description) > 0 else None
+    # except Exception:
+    #     pass
 
-    def get_album_release_date(self, album: Any, album_url: str) -> date | None:
+    def _get_album_release_date(self, album: Any) -> date | None:
         tag: Tag = album
         try:
             release_date = tag.find(
@@ -85,10 +85,7 @@ class MetacriticProvider(BaseProvider[MetacriticSettings]):
         except Exception:
             pass
 
-    def get_wikidata_album_relation_key(self) -> str | None:
-        return "P1712"
-
-    def get_album_rating(self, album: Any, album_url: str) -> int | None:
+    def _get_album_rating(self, album: Any) -> int | None:
         tag: Tag = album
         try:
             raw_value = tag.find("span", attrs={"itemprop": "ratingValue"}).text  # pyright: ignore
@@ -97,6 +94,3 @@ class MetacriticProvider(BaseProvider[MetacriticSettings]):
             return int(raw_value)
         except Exception:
             pass
-
-    def get_album_genres(self, album: Any, album_url: str) -> List[str] | None:
-        pass

--- a/matcher/matcher/providers/metacritic.py
+++ b/matcher/matcher/providers/metacritic.py
@@ -1,18 +1,17 @@
 from dataclasses import dataclass
 from typing import Any, List
+from matcher.providers.features import GetAlbumFeature
 from matcher.settings import MetacriticSettings
 from .base import ArtistSearchResult, BaseProvider, AlbumSearchResult
-from ..models.api.provider import Provider as ApiProviderEntry
 import requests
 from bs4 import BeautifulSoup, Tag
 from datetime import date, datetime
 
 
 @dataclass
-class MetacriticProvider(BaseProvider):
-    api_model: ApiProviderEntry
-    settings: MetacriticSettings
-    pass
+class MetacriticProvider(BaseProvider[MetacriticSettings]):
+    def __post_init__(self):
+        self.features = []
 
     def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
         pass

--- a/matcher/matcher/providers/metacritic.py
+++ b/matcher/matcher/providers/metacritic.py
@@ -24,31 +24,29 @@ class MetacriticProvider(BaseProviderBoilerplate[MetacriticSettings]):
     def __post_init__(self):
         self.features = [
             IsMusicBrainzRelationFeature(
-                lambda _, rel: "metacritic" in rel["url"]["resource"]
+                lambda rel: "metacritic" in rel["url"]["resource"]
             ),
             GetArtistIdFromUrlFeature(
-                lambda _, url: url.replace("https://metacritic.com/person", "")
+                lambda url: url.replace("https://metacritic.com/person", "")
             ),
             GetArtistUrlFromIdFeature(
-                lambda _,
-                artist_id: f"https://www.metacritic.com/person/{artist_id.removeprefix('person/')}"
+                lambda artist_id: f"https://www.metacritic.com/person/{artist_id.removeprefix('person/')}"
             ),
-            GetWikidataArtistRelationKeyFeature(lambda _: "P1712"),
+            GetWikidataArtistRelationKeyFeature(lambda: "P1712"),
             GetAlbumUrlFromIdFeature(
-                lambda _,
-                album_id: f"https://www.metacritic.com/music/{album_id.replace('music/', '')}"
+                lambda album_id: f"https://www.metacritic.com/music/{album_id.replace('music/', '')}"
             ),
             GetAlbumIdFromUrlFeature(
-                lambda _, album_url: album_url.replace(
+                lambda album_url: album_url.replace(
                     "https://www.metacritic.com/music/", ""
                 )
             ),
-            GetWikidataAlbumRelationKeyFeature(lambda _: "P1712"),
-            GetAlbumFeature(lambda _, album_id: self._get_album(album_id)),
+            GetWikidataAlbumRelationKeyFeature(lambda: "P1712"),
+            GetAlbumFeature(lambda album_id: self._get_album(album_id)),
             GetAlbumReleaseDateFeature(
-                lambda _, album: self._get_album_release_date(album)
+                lambda album: self._get_album_release_date(album)
             ),
-            GetAlbumRatingFeature(lambda _, album: self._get_album_rating(album)),
+            GetAlbumRatingFeature(lambda album: self._get_album_rating(album)),
         ]
 
     def _get_album(self, album_id: str) -> Any | None:

--- a/matcher/matcher/providers/musicbrainz.py
+++ b/matcher/matcher/providers/musicbrainz.py
@@ -3,9 +3,9 @@ import logging
 import re
 from typing import Any, List
 from ..utils import capitalize_all_words, to_slug
-from .base import ArtistSearchResult, BaseProvider, AlbumSearchResult
+from .domain import ArtistSearchResult, AlbumSearchResult
 from ..settings import MusicBrainzSettings
-from ..models.api.provider import Provider as ApiProviderEntry
+from .boilerplate import BaseProviderBoilerplate
 import musicbrainzngs
 from musicbrainzngs.musicbrainz import _rate_limit
 import requests
@@ -13,10 +13,7 @@ from datetime import date, datetime
 
 
 @dataclass
-class MusicBrainzProvider(BaseProvider):
-    api_model: ApiProviderEntry
-    settings: MusicBrainzSettings
-
+class MusicBrainzProvider(BaseProviderBoilerplate[MusicBrainzSettings]):
     def __init__(self, api_model, settings) -> None:
         self.api_model = api_model
         self.settings = settings

--- a/matcher/matcher/providers/wikipedia.py
+++ b/matcher/matcher/providers/wikipedia.py
@@ -1,19 +1,16 @@
 from dataclasses import dataclass
 from typing import Any, List
 from urllib.parse import unquote
-from ..models.api.provider import Provider as ApiProviderEntry
+
+from matcher.providers.boilerplate import BaseProviderBoilerplate
 import requests
-from .base import ArtistSearchResult, BaseProvider, AlbumSearchResult
+from .domain import ArtistSearchResult, AlbumSearchResult
 from ..settings import WikipediaSettings
 from datetime import date
 
 
 @dataclass
-class WikipediaProvider(BaseProvider):
-    api_model: ApiProviderEntry
-    settings: WikipediaSettings
-    pass
-
+class WikipediaProvider(BaseProviderBoilerplate[WikipediaSettings]):
     def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
         pass
 

--- a/matcher/matcher/providers/wikipedia.py
+++ b/matcher/matcher/providers/wikipedia.py
@@ -1,21 +1,44 @@
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any
+from .features import (
+    GetArtistDescriptionFeature,
+    GetArtistFeature,
+    GetArtistIdFromUrlFeature,
+    GetArtistUrlFromIdFeature,
+    GetAlbumDescriptionFeature,
+    GetAlbumFeature,
+    GetAlbumIdFromUrlFeature,
+    GetAlbumUrlFromIdFeature,
+)
 from urllib.parse import unquote
-
 from matcher.providers.boilerplate import BaseProviderBoilerplate
 import requests
-from .domain import ArtistSearchResult, AlbumSearchResult
 from ..settings import WikipediaSettings
-from datetime import date
 
 
 @dataclass
 class WikipediaProvider(BaseProviderBoilerplate[WikipediaSettings]):
-    def search_artist(self, artist_name: str) -> ArtistSearchResult | None:
-        pass
-
-    def get_musicbrainz_relation_key(self) -> str | None:
-        return None
+    def __post_init__(self):
+        self.features = [
+            GetArtistIdFromUrlFeature(
+                lambda artist_url: self.get_article_id_from_url(artist_url)
+            ),
+            GetArtistUrlFromIdFeature(
+                lambda artist_id: self.get_article_url_from_id(artist_id)
+            ),
+            GetArtistFeature(lambda artist_id: self.get_article(artist_id)),
+            GetArtistDescriptionFeature(
+                lambda artist: self.get_article_extract(artist)
+            ),
+            GetAlbumIdFromUrlFeature(
+                lambda album_url: self.get_article_id_from_url(album_url)
+            ),
+            GetAlbumUrlFromIdFeature(
+                lambda album_id: self.get_article_url_from_id(album_id)
+            ),
+            GetAlbumFeature(lambda album_id: self.get_article(album_id)),
+            GetAlbumDescriptionFeature(lambda album: self.get_article_extract(album)),
+        ]
 
     def get_article(self, article_id: str) -> Any | None:
         try:
@@ -49,24 +72,7 @@ class WikipediaProvider(BaseProviderBoilerplate[WikipediaSettings]):
     def get_article_url_from_id(self, article_url: str) -> str:
         return f"https://en.wikipedia.org/wiki/{article_url}"
 
-    def get_artist_id_from_url(self, artist_url: str) -> str | None:
-        return self.get_article_id_from_url(artist_url)
-
-    def get_artist_url_from_id(self, artist_id: str) -> str | None:
-        return self.get_article_url_from_id(artist_id)
-
     # the id is the article name
-    def get_artist(self, artist_id: str) -> Any | None:
-        return self.get_article(artist_id)
-
-    def get_artist_description(self, artist: Any, artist_url: str) -> str | None:
-        return self.get_article_extract(artist)
-
-    def get_artist_illustration_url(self, artist: Any, artist_url: str) -> str | None:
-        return None
-
-    def get_wikidata_artist_relation_key(self) -> str | None:
-        pass
 
     def get_article_name_from_wikidata(self, wikidata_id: str) -> str | None:
         try:
@@ -84,33 +90,3 @@ class WikipediaProvider(BaseProviderBoilerplate[WikipediaSettings]):
             return entities[first_entity]["sitelinks"]["enwiki"]["title"]
         except Exception:
             return None
-
-    # Album
-    def search_album(
-        self, album_name: str, artist_name: str | None
-    ) -> AlbumSearchResult | None:
-        pass
-
-    def get_album_url_from_id(self, album_id: str) -> str | None:
-        return self.get_album_url_from_id(album_id)
-
-    def get_album_id_from_url(self, album_url) -> str | None:
-        return self.get_article_id_from_url(album_url)
-
-    def get_album(self, album_id: str) -> Any | None:
-        return self.get_article(album_id)
-
-    def get_album_description(self, album: Any, album_url: str) -> str | None:
-        return self.get_article_extract(album)
-
-    def get_album_release_date(self, album: Any, album_url: str) -> date | None:
-        pass
-
-    def get_wikidata_album_relation_key(self) -> str | None:
-        pass
-
-    def get_album_genres(self, album: Any, album_url: str) -> List[str] | None:
-        pass
-
-    def get_album_rating(self, album: Any, album_url: str) -> int | None:
-        pass

--- a/matcher/tests/providers/allmusic.py
+++ b/matcher/tests/providers/allmusic.py
@@ -1,7 +1,6 @@
 import unittest
 import datetime
 from matcher.context import Context
-from matcher.providers.base import BaseProvider
 from tests.matcher.common import MatcherTestUtils
 from matcher.providers.allmusic import AllMusicProvider
 
@@ -12,19 +11,19 @@ class TestAllMusic(unittest.TestCase):
         MatcherTestUtils.setup_context()
 
     def test_get_album_rating_and_release_date(self):
-        provider: BaseProvider = Context().get().get_provider(AllMusicProvider)  # pyright: ignore
+        provider: AllMusicProvider = Context().get().get_provider(AllMusicProvider)  # pyright: ignore
         album = provider.get_album("mw0004378326")
         self.assertIsNotNone(album)
-        rating = provider.get_album_rating(album, "")
+        rating = provider.get_album_rating(album)
         self.assertEqual(rating, 70)
-        release_date = provider.get_album_release_date(album, "")
+        release_date = provider.get_album_release_date(album)
         self.assertEqual(release_date, datetime.date(2024, 10, 18))
 
     def test_get_album_rating_when_null_and_release_date(self):
-        provider: BaseProvider = Context().get().get_provider(AllMusicProvider)  # pyright: ignore
+        provider: AllMusicProvider = Context().get().get_provider(AllMusicProvider)  # pyright: ignore
         album = provider.get_album("mw0000770491")
         self.assertIsNotNone(album)
-        rating = provider.get_album_rating(album, "")
+        rating = provider.get_album_rating(album)
         self.assertIsNone(rating)
-        release_date = provider.get_album_release_date(album, "")
+        release_date = provider.get_album_release_date(album)
         self.assertEqual(release_date, datetime.date(2003, 3, 24))

--- a/matcher/tests/providers/discogs.py
+++ b/matcher/tests/providers/discogs.py
@@ -1,6 +1,5 @@
 import unittest
 from matcher.context import Context
-from matcher.providers.base import BaseProvider
 from tests.matcher.common import MatcherTestUtils
 from matcher.providers.discogs import DiscogsProvider
 
@@ -11,24 +10,24 @@ class TestDiscogs(unittest.TestCase):
         MatcherTestUtils.setup_context()
 
     def test_search_artist(self):
-        provider: BaseProvider = Context().get().get_provider(DiscogsProvider)  # pyright: ignore
+        provider: DiscogsProvider = Context().get().get_provider(DiscogsProvider)  # pyright: ignore
         artist = provider.search_artist("P!nk")
         self.assertIsNotNone(artist)
         self.assertEqual(artist.id, "36988")  # pyright: ignore
 
     def test_get_artist_description_and_image(self):
-        provider: BaseProvider = Context().get().get_provider(DiscogsProvider)  # pyright: ignore
+        provider: DiscogsProvider = Context().get().get_provider(DiscogsProvider)  # pyright: ignore
         artist = provider.get_artist("4480")
         self.assertIsNotNone(artist)
-        description = provider.get_artist_description(artist, "")
+        description = provider.get_artist_description(artist)
         self.assertIsNotNone(description)
         self.assertIn("Bristol", description)  # pyright: ignore
-        illustration = provider.get_artist_illustration_url(artist, "")
+        illustration = provider.get_artist_illustration_url(artist)
         self.assertIsNotNone(illustration)
 
     def test_get_album_genres(self):
-        provider: BaseProvider = Context().get().get_provider(DiscogsProvider)  # pyright: ignore
+        provider: DiscogsProvider = Context().get().get_provider(DiscogsProvider)  # pyright: ignore
         album = provider.get_album("138437")
         self.assertIsNotNone(album)
-        genres = provider.get_album_genres(album, "")
+        genres = provider.get_album_genres(album)
         self.assertEqual(genres, ["Electronic"])

--- a/matcher/tests/providers/genius.py
+++ b/matcher/tests/providers/genius.py
@@ -1,7 +1,6 @@
 import unittest
 import datetime
 from matcher.context import Context
-from matcher.providers.base import BaseProvider
 from tests.matcher.common import MatcherTestUtils
 from matcher.providers.genius import GeniusProvider
 
@@ -13,35 +12,43 @@ class TestGenius(unittest.TestCase):
 
     @unittest.skipIf(MatcherTestUtils.is_ci(), "")
     def test_search_artist(self):
-        provider: BaseProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
+        provider: GeniusProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
         artist = provider.search_artist("P!nk")
         self.assertIsNotNone(artist)
         self.assertEqual(artist.id, "P!nk")  # pyright: ignore
 
     @unittest.skipIf(MatcherTestUtils.is_ci(), "")
     def test_get_artist_description_and_image(self):
-        provider: BaseProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
+        provider: GeniusProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
         artist = provider.get_artist("Massive Attack")
         self.assertIsNotNone(artist)
-        description = provider.get_artist_description(artist, "")
+        description = provider.get_artist_description(
+            artist,
+        )
         self.assertIsNotNone(description)
         self.assertIn("Bristol", description)  # pyright: ignore
         self.assertIn("and formerly Andy", description)  # pyright: ignore
-        illustration = provider.get_artist_illustration_url(artist, "")
+        illustration = provider.get_artist_illustration_url(
+            artist,
+        )
         self.assertIsNotNone(illustration)
 
     @unittest.skipIf(MatcherTestUtils.is_ci(), "")
     def test_get_artist_without_image(self):
-        provider: BaseProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
+        provider: GeniusProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
         artist = provider.get_artist("Peplab")
         self.assertIsNotNone(artist)
-        illustration = provider.get_artist_illustration_url(artist, "")
+        illustration = provider.get_artist_illustration_url(
+            artist,
+        )
         self.assertIsNone(illustration)
 
     @unittest.skipIf(MatcherTestUtils.is_ci(), "")
     def test_get_album_release_date(self):
-        provider: BaseProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
+        provider: GeniusProvider = Context().get().get_provider(GeniusProvider)  # pyright: ignore
         album = provider.get_album("Superbus/Aeromusical")
         self.assertIsNotNone(album)
-        release_date = provider.get_album_release_date(album, "")
+        release_date = provider.get_album_release_date(
+            album,
+        )
         self.assertEqual(release_date, datetime.date(2002, 3, 26))

--- a/matcher/tests/providers/metacritic.py
+++ b/matcher/tests/providers/metacritic.py
@@ -1,7 +1,6 @@
 import unittest
 import datetime
 from matcher.context import Context
-from matcher.providers.base import BaseProvider
 from tests.matcher.common import MatcherTestUtils
 from matcher.providers.metacritic import MetacriticProvider
 
@@ -12,10 +11,10 @@ class TestMetacritic(unittest.TestCase):
         MatcherTestUtils.setup_context()
 
     def test_get_album_rating_and_release_date(self):
-        provider: BaseProvider = Context().get().get_provider(MetacriticProvider)  # pyright: ignore
-        album = provider.get_album("renaissance/beyonce")
+        provider: MetacriticProvider = Context().get().get_provider(MetacriticProvider)  # pyright: ignore
+        album = provider.get_album("renaissance/beyonce")  # pyright: ignore
         self.assertIsNotNone(album)
-        rating = provider.get_album_rating(album, "")
+        rating = provider.get_album_rating(album)
         self.assertEqual(rating, 91)
-        release_date = provider.get_album_release_date(album, "")
+        release_date = provider.get_album_release_date(album)
         self.assertEqual(release_date, datetime.date(2022, 7, 29))

--- a/matcher/tests/providers/musicbrainz.py
+++ b/matcher/tests/providers/musicbrainz.py
@@ -2,9 +2,8 @@ from typing import List
 import unittest
 import datetime
 from matcher.context import Context
-from matcher.providers.base import BaseProvider
-from tests.matcher.common import MatcherTestUtils
 from matcher.providers.musicbrainz import MusicBrainzProvider
+from tests.matcher.common import MatcherTestUtils
 
 
 class TestMusicbrainz(unittest.TestCase):
@@ -13,59 +12,77 @@ class TestMusicbrainz(unittest.TestCase):
         MatcherTestUtils.setup_context()
 
     def test_search_artist(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         artist = provider.search_artist("P!nk")
         self.assertIsNotNone(artist)
         self.assertEqual(artist.id, "f4d5cc07-3bc9-4836-9b15-88a08359bc63")  # pyright:ignore
 
     def test_get_artist(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         artist = provider.get_artist("45a663b5-b1cb-4a91-bff6-2bef7bbfdd76")
         self.assertIsNotNone(artist)
         self.assertEqual(artist["name"], "Britney Spears")  # pyright:ignore
 
     def test_search_album(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         album = provider.search_album("Protection", "Massive Attack")
         self.assertIsNotNone(album)
         self.assertEqual(album.id, "ded46e46-788d-3c1f-b21b-9f5e9c37b1bc")  # pyright:ignore
 
     def test_search_album_correct_year(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         album = provider.search_album("Revolution In Me", "Siobhan Donaghy")
         self.assertIsNotNone(album)
         self.assertEqual(album.id, "80f800d3-8dd0-3f69-8ddd-fc1e42c55d4c")  # pyright:ignore
 
     def test_search_album_special_char(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         album = provider.search_album("M!ssundaztood", "P!nk")
         self.assertIsNotNone(album)
         self.assertEqual(album.id, "1000b015-e841-3cc4-ab5b-f47931f574e3")  # pyright:ignore
 
     def test_search_album_and_fail(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         album = provider.search_album("Volumen Plus", "Björk")
         self.assertIsNone(album)
 
     def test_search_album_not_single(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         album = provider.search_album("Celebration", "Madonna")
         self.assertIsNotNone(album)
         self.assertEqual(album.id, "bd252c17-ff32-4369-8e73-4d0a65a316bd")  # pyright:ignore
 
     def test_search_single(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         album = provider.search_album("Protection - Single", "Massive Attack")
         self.assertIsNotNone(album)
         self.assertEqual(album.id, "751030cb-44c8-3542-8e75-42b3e4f820fa")  # pyright:ignore
 
     def test_get_album_release_date_and_genres(self):
-        provider: BaseProvider = Context().get().get_provider(MusicBrainzProvider)  # pyright: ignore
+        provider: MusicBrainzProvider = (
+            Context().get().get_provider(MusicBrainzProvider)
+        )  # pyright: ignore
         album = provider.get_album("ded46e46-788d-3c1f-b21b-9f5e9c37b1bc")
         self.assertIsNotNone(album)
-        release_date = provider.get_album_release_date(album, "")
+        release_date = provider.get_album_release_date(album)
         self.assertEqual(release_date, datetime.date(1994, 9, 26))
-        genres: List[str] = provider.get_album_genres(album, "")  # pyright: ignore
+        genres: List[str] = provider.get_album_genres(album)  # pyright: ignore
         self.assertEqual(len(genres), 6)
         self.assertIn("Trip Hop", genres)
         self.assertIn("Electronic", genres)

--- a/matcher/tests/providers/wikipedia.py
+++ b/matcher/tests/providers/wikipedia.py
@@ -1,6 +1,5 @@
 import unittest
 from matcher.context import Context
-from matcher.providers.base import BaseProvider
 from tests.matcher.common import MatcherTestUtils
 from matcher.providers.wikipedia import WikipediaProvider
 
@@ -11,17 +10,17 @@ class TestWikipedia(unittest.TestCase):
         MatcherTestUtils.setup_context()
 
     def test_get_album_description(self):
-        provider: BaseProvider = Context().get().get_provider(WikipediaProvider)  # pyright: ignore
+        provider: WikipediaProvider = Context().get().get_provider(WikipediaProvider)  # pyright: ignore
         album = provider.get_album("Do You Like My Tight Sweater?")
         self.assertIsNotNone(album)
-        description = provider.get_album_description(album, "")
+        description = provider.get_album_description(album)
         self.assertIsNotNone(description)
         self.assertIn("first album", description)  # pyright: ignore
 
     def test_get_artist_description(self):
-        provider: BaseProvider = Context().get().get_provider(WikipediaProvider)  # pyright: ignore
+        provider: WikipediaProvider = Context().get().get_provider(WikipediaProvider)  # pyright: ignore
         artist = provider.get_album("Siobhán Donaghy")
         self.assertIsNotNone(artist)
-        description = provider.get_artist_description(artist, "")
+        description = provider.get_artist_description(artist)
         self.assertIsNotNone(description)
         self.assertIn("Sugababes", description)  # pyright: ignore


### PR DESCRIPTION
To avoid calling a provider that cannot provide info we need, we define a list of feature each provider has.

This changes the internal structure of providers, but it helps us keep provider classes simple, with only the features we need, and not obligatory 'empty' functions required by inheritance

--

This speeds up the matching test by 20/30%