### PR TITLE
Front: Order Videos using Tracklist

### DIFF
--- a/front/src/models/song.ts
+++ b/front/src/models/song.ts
@@ -61,6 +61,7 @@ const Song = Resource.concat(
 		 * The ID of the master track
 		 */
 		masterId: yup.number().required().nullable(),
+		groupId: yup.number().required(),
 		/**
 		 * Type of song
 		 */


### PR DESCRIPTION
Previously, server-side, we ordered videos in the order of an album (this was a dirty hack though).
The way prisma queries work do not allow us to sort videos using a specific release.

As a workaround, we sort video on client-side. The ordering is optimized so that we go through the tracklist only as many times as there are videos to sort. We use the song group to order them.

The result is: videos are sorted in the order of the tracklist.
<img width="1168" alt="Screenshot 2024-12-13 at 20 33 32" src="https://github.com/user-attachments/assets/1ab9e7c4-ea07-4497-b29a-94149b28637e" />
