### PR TITLE
Front: Disable Spellcheck in Search Field

### DIFF
--- a/front/src/pages/search/[[...query]].tsx
+++ b/front/src/pages/search/[[...query]].tsx
@@ -182,6 +182,10 @@ const SearchPage: Page<GetPropsTypesFrom<typeof prepareSSR>> = ({ props }) => {
 					}}
 					InputProps={{
 						value: inputValue,
+						autoComplete: "off",
+						autoCorrect: "off",
+						spellCheck: false,
+						autoCapitalize: "off",
 						startAdornment: (
 							<InputAdornment position="start">
 								<SearchIcon />


### PR DESCRIPTION
We prevent browser to suggest and correct user input in search bar. When this happens, it can replace text, save, trigger a fetch and change the search results before user can do anything