### PR TITLE
Server: Simplify env setup for tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,11 +15,10 @@
 		"start:dev": "NODE_ENV=development nest start --watch",
 		"start:debug": "nest start --debug --watch",
 		"start:prod": "node dist/src/main",
-		"test:setup": "docker run -d --rm --env-file ../.env -p 5432:5432 --name test-db postgres:alpine3.16 ; docker run -d --rm --env-file ../.env -p 7700:7700 --name test-meili getmeili/meilisearch:v1.5 ; sleep 3; POSTGRES_HOST=localhost yarn run prisma migrate dev",
+		"test:setup": "docker run -d --rm --env-file .env -p 5432:5432 --name test-db postgres:alpine3.16 ; docker run -d --rm --env-file .env -p 7700:7700 --name test-meili getmeili/meilisearch:v1.5 ; sleep 3; yarn run prisma migrate dev",
 		"test:teardown": "docker container stop test-db ; docker container stop test-meili",
-		"test": "API_KEY=a INTERNAL_CONFIG_DIR=test/assets/ INTERNAL_DATA_DIR=test/assets/ jest -i",
-		"test:cov": "yarn test --coverage",
-		"test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
+		"test": "JWT_SIGNATURE=AAAAAA API_KEY=a INTERNAL_CONFIG_DIR=test/assets/ INTERNAL_DATA_DIR=test/assets/ jest -i",
+		"test:cov": "yarn test --coverage"
 	},
 	"dependencies": {
 		"@nestjs/axios": "^4.0.0",


### PR DESCRIPTION
Remove dependency of top-level `.env` file to setup tests.