### PR TITLE
Front: Normalize color for CSS

### DIFF
--- a/front/src/models/illustration.ts
+++ b/front/src/models/illustration.ts
@@ -31,7 +31,17 @@ const Illustration = yup
 		 * Aspect Ratio of The Image
 		 */
 		aspectRatio: yup.number().required(),
-		colors: yup.array(yup.string().required()).required(),
+		colors: yup
+			.array(
+				yup
+					.string()
+					.required()
+					.transform((color: string) => {
+						const afterHash = color.slice(1);
+						return `#${afterHash.padStart(6, "0")}`;
+					}),
+			)
+			.required(),
 	})
 	.required();
 


### PR DESCRIPTION
Fix illustration colours not being 6-chars long, leading to transparent surfaces