### PR TITLE
Add an icon with the song type

### DIFF
--- a/front/src/components/icons.tsx
+++ b/front/src/components/icons.tsx
@@ -91,3 +91,15 @@ export const MinusIcon = Iconsax.Minus;
 export const DoneIcon = Iconsax.TickSquare;
 
 export const EmptyStateIcon = Iconsax.SearchStatus1;
+
+// Icons for song type
+export const SongTypeRemixIcon = Iconsax.Repeat;
+export const SongTypeLiveIcon = Iconsax.Microphone2;
+export const SongTypeAcousticIcon = Iconsax.VoiceSquare;
+export const SongTypeInstrumentalIcon = Iconsax.Musicnote;
+export const SongTypeEditIcon = Iconsax.Edit2;
+export const SongTypeCleanIcon = Iconsax.TickCircle;
+export const SongTypeDemoIcon = Iconsax.MonitorRecorder;
+export const SongTypeAcapellaIcon = Iconsax.VoiceCricle;
+export const SongTypeMedleyIcon = Iconsax.Layer;
+export const SongTypeNonMusicIcon = Iconsax.VolumeSlash;

--- a/front/src/components/list-item/item.tsx
+++ b/front/src/components/list-item/item.tsx
@@ -24,6 +24,7 @@ import {
 	ListItemText,
 	ListItem as MUIListItem,
 	Skeleton,
+	Stack,
 	Typography,
 	useTheme,
 } from "@mui/material";
@@ -32,6 +33,7 @@ import Link from "next/link";
 type ListItemProps = {
 	icon?: JSX.Element;
 	title: string | undefined;
+	titleIcon?: JSX.Element;
 	secondTitle: string | undefined | null;
 	trailing?: JSX.Element;
 	href?: string;
@@ -54,6 +56,19 @@ const secondaryTextStyle = {
 const ListItem = (props: ListItemProps) => {
 	const _theme = useTheme();
 
+	const makeTitleElement = () => {
+		if (props.title === undefined) {
+			return <Skeleton width={"120px"} />;
+		}
+
+		return (
+			<Stack direction="row" spacing={0.5} alignItems="center">
+				{props.titleIcon}
+				{props.title}
+			</Stack>
+		);
+	};
+
 	return (
 		<MUIListItem disablePadding secondaryAction={props.trailing}>
 			<ListItemButton
@@ -74,8 +89,11 @@ const ListItem = (props: ListItemProps) => {
 					}}
 				>
 					<ListItemText
-						primary={props.title ?? <Skeleton width={"120px"} />}
-						primaryTypographyProps={primaryTextStyle}
+						primary={makeTitleElement()}
+						primaryTypographyProps={{
+							...primaryTextStyle,
+							component: "div"
+						}}
 						secondary={
 							props.secondTitle === undefined ? (
 								<Skeleton width={"70px"} />
@@ -93,8 +111,8 @@ const ListItem = (props: ListItemProps) => {
 					sx={{ display: { xs: "none", xl: "flex" }, width: "100%" }}
 				>
 					<Grid item xs={props.secondTitle !== null ? 6 : 10}>
-						<Typography sx={{ ...textStyle, ...primaryTextStyle }}>
-							{props.title ?? <Skeleton width={"120px"} />}
+						<Typography sx={{ ...textStyle, ...primaryTextStyle }} component="div">
+							{makeTitleElement()}
 						</Typography>
 					</Grid>
 					{props.secondTitle === null ? undefined : (

--- a/front/src/components/list-item/song-item.tsx
+++ b/front/src/components/list-item/song-item.tsx
@@ -25,6 +25,7 @@ import formatArtists from "../../utils/formatArtists";
 import SongContextualMenu from "../contextual-menu/song-contextual-menu";
 import { SongIcon } from "../icons";
 import Illustration from "../illustration";
+import SongTypeIcon from "../song-type-icon";
 import ListItem from "./item";
 
 type SongItemProps<
@@ -125,6 +126,7 @@ const SongItem = <
 				/>
 			}
 			title={song?.name}
+			titleIcon={song ? <SongTypeIcon type={song.type} /> : undefined}
 			onClick={
 				song &&
 				artist &&

--- a/front/src/components/release-tracklist.tsx
+++ b/front/src/components/release-tracklist.tsx
@@ -28,6 +28,7 @@ import {
 	ListItemText,
 	ListSubheader,
 	Skeleton,
+	Stack,
 	Typography,
 	useTheme,
 } from "@mui/material";
@@ -53,6 +54,7 @@ import formatDuration from "../utils/formatDuration";
 import { generateArray } from "../utils/gen-list";
 import ReleaseTrackContextualMenu from "./contextual-menu/release-track-contextual-menu";
 import { ContextualMenuIcon, VideoIcon } from "./icons";
+import SongTypeIcon from "./song-type-icon";
 
 type TrackType = TrackWithRelations<"illustration"> &
 	RequireAtLeastOne<{
@@ -214,12 +216,18 @@ const ReleaseTrackList = ({
 										</ListItemIcon>
 										<ListItemText
 											primary={
-												currentTrack?.name ?? (
+												currentTrack ? (
+													<Stack direction="row" spacing={0.5} alignItems="center">
+														{currentTrack.song && <SongTypeIcon type={currentTrack.song.type} />}
+														{currentTrack.name}
+													</Stack>
+												) : (
 													<Skeleton width="120px" />
 												)
 											}
 											primaryTypographyProps={{
 												fontSize: "medium",
+												component: "div"
 											}}
 											secondary={
 												mainArtist === undefined

--- a/front/src/components/song-grid.tsx
+++ b/front/src/components/song-grid.tsx
@@ -25,6 +25,7 @@ import SongContextualMenu from "./contextual-menu/song-contextual-menu";
 import { SongIcon } from "./icons";
 import Illustration from "./illustration";
 import ListItem from "./list-item/item";
+import SongTypeIcon from "./song-type-icon";
 
 type SongGridProps = {
 	songs: (
@@ -55,6 +56,7 @@ const SongGrid = ({ songs, parentArtistName }: SongGridProps) => {
 							/>
 						}
 						title={song?.name}
+						titleIcon={song ? <SongTypeIcon type={song.type} /> : undefined}
 						secondTitle={
 							song
 								? parentArtistName === song.artist.name &&

--- a/front/src/components/song-type-icon.tsx
+++ b/front/src/components/song-type-icon.tsx
@@ -1,0 +1,66 @@
+/*
+ * Meelo is a music server and application to enjoy your personal music files anywhere, anytime you want.
+ * Copyright (C) 2023
+ *
+ * Meelo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Meelo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Box, Tooltip } from "@mui/material";
+import { type SongType } from "../models/song";
+import {
+    SongIcon,
+    SongTypeAcapellaIcon,
+    SongTypeAcousticIcon,
+    SongTypeCleanIcon,
+    SongTypeDemoIcon,
+    SongTypeEditIcon,
+    SongTypeInstrumentalIcon,
+    SongTypeLiveIcon,
+    SongTypeMedleyIcon,
+    SongTypeNonMusicIcon,
+    SongTypeRemixIcon
+} from "./icons";
+
+const SongTypeIcon = ({ type, size = 20 }: { type: SongType; size?: number }) => {
+    const getIcon = () => {
+        switch (type) {
+            // We don't show an icon for original songs, since that's the most common type
+            case 'Original': return null;
+            case 'Remix': return <SongTypeRemixIcon size={size} />;
+            case 'Live': return <SongTypeLiveIcon size={size} />;
+            case 'Acoustic': return <SongTypeAcousticIcon size={size} />;
+            case 'Instrumental': return <SongTypeInstrumentalIcon size={size} />;
+            case 'Edit': return <SongTypeEditIcon size={size} />;
+            case 'Clean': return <SongTypeCleanIcon size={size} />;
+            case 'Demo': return <SongTypeDemoIcon size={size} />;
+            case 'Acappella': return <SongTypeAcapellaIcon size={size} />;
+            case 'Medley': return <SongTypeMedleyIcon size={size} />;
+            case 'NonMusic': return <SongTypeNonMusicIcon size={size} />;
+            default: return <SongIcon size={size} />;
+        }
+    };
+
+    const icon = getIcon();
+    if (!icon) return null;
+
+    return (
+        <Tooltip title={type} arrow>
+            <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', marginRight: 1, opacity: 0.8 }}>
+                {icon}
+            </Box>
+        </Tooltip>
+    );
+};
+
+export default SongTypeIcon;

--- a/front/src/components/song-type-icon.tsx
+++ b/front/src/components/song-type-icon.tsx
@@ -17,6 +17,7 @@
  */
 
 import { Box, Tooltip } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import { type SongType } from "../models/song";
 import {
     SongIcon,
@@ -33,6 +34,8 @@ import {
 } from "./icons";
 
 const SongTypeIcon = ({ type, size = 20 }: { type: SongType; size?: number }) => {
+    const { t } = useTranslation();
+
     const getIcon = () => {
         switch (type) {
             // We don't show an icon for original songs, since that's the most common type
@@ -55,7 +58,7 @@ const SongTypeIcon = ({ type, size = 20 }: { type: SongType; size?: number }) =>
     if (!icon) return null;
 
     return (
-        <Tooltip title={type} arrow>
+        <Tooltip title={t(type) as string} arrow>
             <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', marginRight: 1, opacity: 0.8 }}>
                 {icon}
             </Box>

--- a/front/src/pages/playlists/[slugOrId]/index.tsx
+++ b/front/src/pages/playlists/[slugOrId]/index.tsx
@@ -54,6 +54,7 @@ import {
 import Illustration from "../../../components/illustration";
 import ListItem from "../../../components/list-item/item";
 import RelationPageHeader from "../../../components/relation-page-header/relation-page-header";
+import SongTypeIcon from "../../../components/song-type-icon";
 import type {
 	PlaylistEntry,
 	PlaylistEntryWithRelations,
@@ -202,6 +203,7 @@ const PlaylistEntryItem = ({ entry, onClick }: PlaylistEntryItemProps) => (
 			/>
 		}
 		title={entry?.name}
+		titleIcon={entry ? <SongTypeIcon type={entry.type} /> : undefined}
 		onClick={onClick}
 		trailing={
 			entry && <SongContextualMenu song={entry} entryId={entry.entryId} />


### PR DESCRIPTION
This simply adds a small icon next to the song's name matching the song's type.  
This is useful to get the type at a glance, especially since right now the only way to see it is (as far as i'm aware) to go in the "change song type" modal.

I didn't add any icon for the "Original" song type, since that will be the one used on most songs anyways. 
That way icons are only shown for the few songs that have a different type, avoiding clutter.

Also note that the icons used right now are probably not the best (especially for acoustic and a capella), but i wanted to reuse Iconsax as much as possible. It would probably be a good idea to change a few of these for something from another icon set though.

## Song view
![Song view](https://github.com/user-attachments/assets/c3975a58-e4ee-4d27-874d-e6316c8c0f0c) 

## Album view
![Album view](https://github.com/user-attachments/assets/a37b3f22-4182-4780-b7c1-beb9ce437244) | 

