### PR TITLE
Use the embeded video illustration as thumbnail if one exists

### DIFF
--- a/scanner/internal/config/user_settings.go
+++ b/scanner/internal/config/user_settings.go
@@ -38,10 +38,10 @@ const (
 )
 
 type UserSettings struct {
-	Compilations CompilationSettings `json:"compilations" validate:"required"`
-	TrackRegex   []string            `json:"trackRegex" validate:"required"`
-	Metadata     MetadataSettings    `json:"metadata" validate:"required"`
-	UseEmbeddedThumbnails bool       `json:"useEmbeddedThumbnails"`
+	Compilations          CompilationSettings `json:"compilations" validate:"required"`
+	TrackRegex            []string            `json:"trackRegex" validate:"required"`
+	Metadata              MetadataSettings    `json:"metadata" validate:"required"`
+	UseEmbeddedThumbnails bool                `json:"useEmbeddedThumbnails"`
 }
 
 func GetUserSettings(settingsFilePath string) (UserSettings, []error) {

--- a/scanner/internal/config/user_settings.go
+++ b/scanner/internal/config/user_settings.go
@@ -41,6 +41,7 @@ type UserSettings struct {
 	Compilations CompilationSettings `json:"compilations" validate:"required"`
 	TrackRegex   []string            `json:"trackRegex" validate:"required"`
 	Metadata     MetadataSettings    `json:"metadata" validate:"required"`
+	UseEmbeddedThumbnails bool       `json:"useEmbeddedThumbnails"`
 }
 
 func GetUserSettings(settingsFilePath string) (UserSettings, []error) {

--- a/scanner/internal/parser/embedded.go
+++ b/scanner/internal/parser/embedded.go
@@ -149,9 +149,12 @@ func parseMetadataFromEmbeddedTags(filePath string, c config.UserSettings) (inte
 			}
 		})
 	}
-	if streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData); streamIndex >= 0 {
-		metadata.IllustrationLocation = internal.Embedded
-		metadata.IllustrationStreamIndex = streamIndex
+
+	if !c.UseEmbeddedThumbnails {
+		if streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData); streamIndex >= 0 {
+			metadata.IllustrationLocation = internal.Embedded
+			metadata.IllustrationStreamIndex = streamIndex
+		}
 	}
 	return metadata, errors
 }

--- a/scanner/internal/tasks/illustration.go
+++ b/scanner/internal/tasks/illustration.go
@@ -14,70 +14,31 @@ import (
 )
 
 func SaveThumbnail(t ThumbnailTask, c config.Config) error {
-	var thumbnailbytes []byte
-	var err error
-	var hasValidEmbeddedThumbnail bool = false
-
-	// If the video has an embedded illustration, we try to use that as the thumbnail
+	// If the video has an embedded illustration, use that as the thumbnail
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
-	// Try to extract embedded thumbnail if available
-	if probeData, err := ffprobe.ProbeURL(ctx, t.FilePath); err == nil {
-		if streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData); streamIndex >= 0 {
-			// We found an embedded image stream, now we check if it's a valid thumbnail
-			// A thumbnail is "valid" if it has the same aspect ratio as the video (with a margin of error of 5%)
-			const marginOfError = 0.05
-			var videoWidth, videoHeight float64
-			var imageWidth, imageHeight float64
-
-			// Get video dimensions
-			for _, stream := range probeData.Streams {
-				if stream != nil && stream.CodecType == "video" && stream.Index != streamIndex {
-					videoWidth = float64(stream.Width)
-					videoHeight = float64(stream.Height)
-					break
-				}
-			}
-
-			// Get image dimensions
-			for _, stream := range probeData.Streams {
-				if stream != nil && stream.Index == streamIndex {
-					imageWidth = float64(stream.Width)
-					imageHeight = float64(stream.Height)
-					break
-				}
-			}
-
-			// Check aspect ratio
-			if videoWidth > 0 && videoHeight > 0 && imageWidth > 0 && imageHeight > 0 {
-				videoAspect := videoWidth / videoHeight
-				imageAspect := imageWidth / imageHeight
-
-				if imageAspect >= videoAspect*(1-marginOfError) && imageAspect <= videoAspect*(1+marginOfError) {
-					// Try to extract the embedded thumbnail
-					var extractErr error
-					thumbnailbytes, extractErr = illustration.ExtractEmbeddedIllustration(t.FilePath, streamIndex)
-					if extractErr == nil {
-						hasValidEmbeddedThumbnail = true
-					}
-				}
+	
+	probeData, err := ffprobe.ProbeURL(ctx, t.FilePath)
+	if err == nil {
+		streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData)
+		if streamIndex >= 0 {
+			thumbnailbytes, err := illustration.ExtractEmbeddedIllustration(t.FilePath, streamIndex)
+			if err == nil {
+				return api.PostIllustration(c, t.TrackId, api.Thumbnail, thumbnailbytes)
 			}
 		}
 	}
-
-	// If there is no valid embedded illustration, we instead extract a frame from the video
-	if !hasValidEmbeddedThumbnail {
-		thumbnailPosition := int64(t.TrackDuration / 2)
-		if t.TrackDuration == 0 {
-			t.TrackDuration = 5 // this is abitrary. If the scan os path only, we do not get the duration.
-		}
-
-		thumbnailbytes, err = illustration.GetFrame(t.FilePath, thumbnailPosition)
-		if err != nil {
-			return err
-		}
+	
+	// If there is no embedded illustration, we instead extract a frame from the video
+	thumbnailPosition := int64(t.TrackDuration / 2)
+	if t.TrackDuration == 0 {
+		t.TrackDuration = 5 // this is abitrary. If the scan os path only, we do not get the duration.
 	}
 
+	thumbnailbytes, err := illustration.GetFrame(t.FilePath, thumbnailPosition)
+	if err != nil {
+		return err
+	}
 	return api.PostIllustration(c, t.TrackId, api.Thumbnail, thumbnailbytes)
 }
 

--- a/scanner/internal/tasks/illustration.go
+++ b/scanner/internal/tasks/illustration.go
@@ -14,31 +14,70 @@ import (
 )
 
 func SaveThumbnail(t ThumbnailTask, c config.Config) error {
-	// If the video has an embedded illustration, use that as the thumbnail
+	var thumbnailbytes []byte
+	var err error
+	var hasValidEmbeddedThumbnail bool = false
+
+	// If the video has an embedded illustration, we try to use that as the thumbnail
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
-	
-	probeData, err := ffprobe.ProbeURL(ctx, t.FilePath)
-	if err == nil {
-		streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData)
-		if streamIndex >= 0 {
-			thumbnailbytes, err := illustration.ExtractEmbeddedIllustration(t.FilePath, streamIndex)
-			if err == nil {
-				return api.PostIllustration(c, t.TrackId, api.Thumbnail, thumbnailbytes)
+	// Try to extract embedded thumbnail if available
+	if probeData, err := ffprobe.ProbeURL(ctx, t.FilePath); err == nil {
+		if streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData); streamIndex >= 0 {
+			// We found an embedded image stream, now we check if it's a valid thumbnail
+			// A thumbnail is "valid" if it has the same aspect ratio as the video (with a margin of error of 5%)
+			const marginOfError = 0.05
+			var videoWidth, videoHeight float64
+			var imageWidth, imageHeight float64
+
+			// Get video dimensions
+			for _, stream := range probeData.Streams {
+				if stream != nil && stream.CodecType == "video" && stream.Index != streamIndex {
+					videoWidth = float64(stream.Width)
+					videoHeight = float64(stream.Height)
+					break
+				}
+			}
+
+			// Get image dimensions
+			for _, stream := range probeData.Streams {
+				if stream != nil && stream.Index == streamIndex {
+					imageWidth = float64(stream.Width)
+					imageHeight = float64(stream.Height)
+					break
+				}
+			}
+
+			// Check aspect ratio
+			if videoWidth > 0 && videoHeight > 0 && imageWidth > 0 && imageHeight > 0 {
+				videoAspect := videoWidth / videoHeight
+				imageAspect := imageWidth / imageHeight
+
+				if imageAspect >= videoAspect*(1-marginOfError) && imageAspect <= videoAspect*(1+marginOfError) {
+					// Try to extract the embedded thumbnail
+					var extractErr error
+					thumbnailbytes, extractErr = illustration.ExtractEmbeddedIllustration(t.FilePath, streamIndex)
+					if extractErr == nil {
+						hasValidEmbeddedThumbnail = true
+					}
+				}
 			}
 		}
 	}
-	
-	// If there is no embedded illustration, we instead extract a frame from the video
-	thumbnailPosition := int64(t.TrackDuration / 2)
-	if t.TrackDuration == 0 {
-		t.TrackDuration = 5 // this is abitrary. If the scan os path only, we do not get the duration.
+
+	// If there is no valid embedded illustration, we instead extract a frame from the video
+	if !hasValidEmbeddedThumbnail {
+		thumbnailPosition := int64(t.TrackDuration / 2)
+		if t.TrackDuration == 0 {
+			t.TrackDuration = 5 // this is abitrary. If the scan os path only, we do not get the duration.
+		}
+
+		thumbnailbytes, err = illustration.GetFrame(t.FilePath, thumbnailPosition)
+		if err != nil {
+			return err
+		}
 	}
 
-	thumbnailbytes, err := illustration.GetFrame(t.FilePath, thumbnailPosition)
-	if err != nil {
-		return err
-	}
 	return api.PostIllustration(c, t.TrackId, api.Thumbnail, thumbnailbytes)
 }
 

--- a/scanner/internal/tasks/illustration.go
+++ b/scanner/internal/tasks/illustration.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -9,9 +10,26 @@ import (
 	"github.com/Arthi-chaud/Meelo/scanner/internal/api"
 	"github.com/Arthi-chaud/Meelo/scanner/internal/config"
 	"github.com/Arthi-chaud/Meelo/scanner/internal/illustration"
+	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
 func SaveThumbnail(t ThumbnailTask, c config.Config) error {
+	// If the video has an embedded illustration, use that as the thumbnail
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	
+	probeData, err := ffprobe.ProbeURL(ctx, t.FilePath)
+	if err == nil {
+		streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData)
+		if streamIndex >= 0 {
+			thumbnailbytes, err := illustration.ExtractEmbeddedIllustration(t.FilePath, streamIndex)
+			if err == nil {
+				return api.PostIllustration(c, t.TrackId, api.Thumbnail, thumbnailbytes)
+			}
+		}
+	}
+	
+	// If there is no embedded illustration, we instead extract a frame from the video
 	thumbnailPosition := int64(t.TrackDuration / 2)
 	if t.TrackDuration == 0 {
 		t.TrackDuration = 5 // this is abitrary. If the scan os path only, we do not get the duration.

--- a/settings.json
+++ b/settings.json
@@ -16,5 +16,6 @@
 		"artists": [
 			"Various Artists"
 		]
-	}
+	},
+	"useEmbeddedThumbnails": false
 }


### PR DESCRIPTION
When generating a thumbnail for a video, we now first check if it contains an embedded illustration. If it does, we use that as the thumbnail.
In case it doesn't, we fall back to the existing implementation of using a frame from the video.