### PR TITLE
Prevent default on "/" keypress event to prevent quick find from opening

### DIFF
--- a/front/src/contexts/keybindings.tsx
+++ b/front/src/contexts/keybindings.tsx
@@ -71,6 +71,10 @@ const useKey = (...p: Parameters<typeof _useKey>) => {
 			if (tagName === "input" || tagName === "textarea") {
 				return;
 			}
+			// Prevent default for the "/" key to stop Firefox's quick find
+			if (p[0] === "/") {
+				e.preventDefault();
+			}
 			p[1]?.(e);
 		},
 		p[2],


### PR DESCRIPTION
On Firefox, pressing the `/` key opens a bar at the bottom of the screen for the "quick find" feature.
This PR prevents that behavior, so users trying to go to the search page with the shortcut don't end up opening quick find. 