### PR TITLE
Only skip using the embedded thumbnail as illustrations for videos

### DIFF
--- a/scanner/internal/parser/embedded.go
+++ b/scanner/internal/parser/embedded.go
@@ -150,7 +150,7 @@ func parseMetadataFromEmbeddedTags(filePath string, c config.UserSettings) (inte
 		})
 	}
 
-	if !c.UseEmbeddedThumbnails {
+	if !c.UseEmbeddedThumbnails || metadata.Type != internal.Video {
 		if streamIndex := illustration.GetEmbeddedIllustrationStreamIndex(*probeData); streamIndex >= 0 {
 			metadata.IllustrationLocation = internal.Embedded
 			metadata.IllustrationStreamIndex = streamIndex


### PR DESCRIPTION
If `useEmbeddedThumbnails` is set to true, we don't extract the embedded illustration for use as album cover, so we can instead use it as thumbnail.  
However, this currently also skips using the embedded illustration for non-video songs, despite the embedded illustration not being used as a thumbnail (as far as i know). This results in music albums without a cover.jpg being cover-less without real purpose.

As a side-note, i wonder if the check could be removed entirely, to me it seems better to have a thumbnail as album cover rather than no album cover at all (especially since setting `useEmbeddedThumbnails` to false will result in the would-be thumbnails being used as album covers instead)

And i apologize for not catching during the original PR, i misunderstood what this chunk of code did so i didn't question the requested change.