### PR TITLE
Docker: remove unused profile definitions

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -134,7 +134,6 @@ services:
     volumes:
       - ${DATA_DIR}:${INTERNAL_DATA_DIR}:ro
       - transcoder_cache:/cache
-    profiles: ['', 'cpu']
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -121,7 +121,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    profiles: ['', 'cpu']
   mq:
     image: rabbitmq:4.0-alpine
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,6 @@ services:
     volumes:
       - ${DATA_DIR}:${INTERNAL_DATA_DIR}:ro
       - transcoder_cache:/cache
-    profiles: ['', 'cpu']
   db:
     image: postgres:alpine3.14
     healthcheck:


### PR DESCRIPTION
This should close #969 cause as explained the profiles definitions do not make any sense in this context as the compose is created to only support the cpu/default option which is good enough for music and the occasionally odd video.