### PR TITLE
Front: Add progress + rewind button on minimised player

### DIFF
--- a/front/apps/web/src/components/player/controls/minimized.tsx
+++ b/front/apps/web/src/components/player/controls/minimized.tsx
@@ -19,14 +19,20 @@
 import { useQuery } from "@/api/hook";
 import { TrackIcon } from "@/components/icons";
 import Illustration from "@/components/illustration";
+import type IllustrationModel from "@/models/illustration";
 import formatArtists from "@/utils/format-artists";
 import {
+	Box,
+	type BoxProps,
 	ButtonBase,
 	Grid,
 	Skeleton,
 	Typography,
 	useTheme,
 } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useAccentColor } from "~/utils/accent-color";
+import { useThemedSxValue } from "~/utils/themed-sx-value";
 import {
 	PlayButton,
 	type PlayerControlsProps,
@@ -36,19 +42,80 @@ import {
 	playerTextStyle,
 } from "./common";
 
+const ProgressBar = ({
+	progress,
+	duration,
+	illustration,
+	boxProps,
+}: Pick<PlayerControlsProps, "progress" | "duration"> & {
+	illustration: IllustrationModel | null | undefined;
+} & Record<"boxProps", BoxProps>) => {
+	const theme = useTheme();
+	const accentColorHook = useAccentColor(illustration);
+	const [progressState, setProgress] = useState(0);
+	const accentColor = useThemedSxValue(
+		"borderTopColor",
+		accentColorHook?.light,
+		accentColorHook?.dark,
+	);
+
+	useEffect(() => {
+		const cb = () => {
+			setProgress(
+				!duration
+					? 0
+					: (100 * (progress?.current ?? 0)) / (duration ?? 1),
+			);
+		};
+		const tm = setInterval(cb, 200);
+		return () => {
+			clearInterval(tm);
+		};
+	});
+
+	return (
+		<Box
+			sx={{
+				...boxProps,
+				borderRadius: theme.shape.borderRadius,
+				borderTop: "3px solid",
+				...accentColor,
+				width: `${progressState}%`,
+				position: "absolute",
+				transition: "width .2s ease-in-out",
+			}}
+		/>
+	);
+};
+
 export const MinimizedPlayerControls = (props: PlayerControlsProps) => {
 	const parentSong = useQuery(
 		parentSongQuery,
 		props.track?.songId ?? undefined,
 	);
 	const theme = useTheme();
-
 	return (
 		<ButtonBase
 			onClick={() => props.onExpand(true)}
 			disableTouchRipple
-			sx={{ width: "100%", height: "100%", padding: 0, margin: 0 }}
+			sx={{
+				width: "100%",
+				height: "100%",
+				padding: 0,
+				margin: 0,
+				position: "relative",
+				paddingBottom: "1px",
+			}}
 		>
+			<ProgressBar
+				progress={props.progress}
+				illustration={props.track?.illustration}
+				duration={props.duration}
+				boxProps={{
+					bottom: -8,
+					left: -8,
+				}}
+			/>
 			<Grid
 				container
 				spacing={1.5}
@@ -57,6 +124,7 @@ export const MinimizedPlayerControls = (props: PlayerControlsProps) => {
 					display: "flex",
 					width: "100%",
 					justifyContent: "center",
+					overflow: "hidden",
 				}}
 			>
 				<Grid sx={{ minWidth: "52px" }}>

--- a/front/apps/web/src/components/player/controls/minimized.tsx
+++ b/front/apps/web/src/components/player/controls/minimized.tsx
@@ -30,6 +30,7 @@ import {
 import {
 	PlayButton,
 	type PlayerControlsProps,
+	PreviousButton,
 	SkipButton,
 	parentSongQuery,
 	playerTextStyle,
@@ -144,11 +145,17 @@ export const MinimizedPlayerControls = (props: PlayerControlsProps) => {
 				</Grid>
 				<Grid
 					container
-					size={{ xs: 4, sm: 3, md: 2 }}
+					size={{ xs: 4, sm: 4, md: 4, lg: 3, xl: 2 }}
 					flexWrap="nowrap"
 					color={props.playlistLoading ? "text.disabled" : undefined}
 					onClick={(event) => event.stopPropagation()}
 				>
+					<Grid
+						size="grow"
+						sx={{ display: { xs: "none", sm: "block" } }}
+					>
+						<PreviousButton onClick={props.onRewind} />
+					</Grid>
 					<Grid size="grow">
 						<PlayButton
 							onPause={props.onPause}

--- a/front/apps/web/src/components/player/controls/slider.tsx
+++ b/front/apps/web/src/components/player/controls/slider.tsx
@@ -75,6 +75,7 @@ const PlayerSlider = (props: PlayerSliderProps) => {
 							style: {
 								height: 5,
 								minWidth: 5,
+								transition: "width .2s ease-in",
 								// Note: It overflows at the border at the very end of the track
 								// not worth trying to figure  out
 								// borderStartEndRadius: 0,

--- a/front/apps/web/src/components/player/index.tsx
+++ b/front/apps/web/src/components/player/index.tsx
@@ -507,6 +507,7 @@ const Player = () => {
 							display: "flex",
 							width: "100%",
 							height: "fit-content",
+							overflow: "hidden",
 							background: playerBgColor,
 							transition: transition,
 							backdropFilter: blur,


### PR DESCRIPTION
Closes #1032 

# Preview

## For regular/desktop viewports
<img width="1241" alt="Screenshot 2025-06-06 at 09 18 51" src="https://github.com/user-attachments/assets/ddc5d985-3575-4a62-b81d-6fc88ef4d5fe" />

## For smaller/mobile viewports
<img width="566" alt="Screenshot 2025-06-06 at 09 19 05" src="https://github.com/user-attachments/assets/9247b4c7-60ab-40bf-81e2-9e49188ac1cc" />
