### PR TITLE
Front: Resource types: fix translation keys for singular

### DIFF
--- a/front/packages/models/src/utils.ts
+++ b/front/packages/models/src/utils.ts
@@ -86,10 +86,10 @@ export const songTypeToTranslationKey = (
 	songType: SongType,
 	plural: boolean,
 ): TranslationKey =>
-	`songType.${uncapitalize(songType)}${plural ? "_plural" : "plural"}`;
+	`songType.${uncapitalize(songType)}${plural ? "_plural" : ""}`;
 
 export const videoTypeToTranslationKey = (
 	videoType: VideoType,
 	plural: boolean,
 ): TranslationKey =>
-	`videoType.${uncapitalize(videoType)}${plural ? "_plural" : "plural"}`;
+	`videoType.${uncapitalize(videoType)}${plural ? "_plural" : ""}`;


### PR DESCRIPTION
Fix translation keys for song and video types

Spotted by @ramazanix and originally fixed in #1053 