### PR TITLE
Docs: Update server's README with `ENABLE_USER_REGISTRATION` environment variable info

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -12,6 +12,7 @@
   - Example: `http://transcoder:7666`
 - `API_KEYS`: List of comma separated keys used by microservices (e.g. scanner) to authenticate
 - `JWT_SIGNATURE`: Random String used to sign JWT Tokens
+- `ENABLE_USER_REGISTRATION`: If set to `0`, users will not be able to create accounts. Do not set this to `0` if you haven't created the first admin account yet
 - `ALLOW_ANONYMOUS`: If `1`, anonymous requests will be allowed on read-only endpoints
 - `INTERNAL_CONFIG_DIR`: Path of the directory that contains the `settings.json` file
 - `INTERNAL_DATA_DIR`: Path of the directory where all the libraries are.


### PR DESCRIPTION
Documenting the `ENABLE_USER_REGISTRATION` environment variable located here: https://github.com/Arthi-chaud/Meelo/blob/5de296a4b6ceb8d6c04dbc8967909de59632251d/server/src/settings/settings.service.ts#L53-L55

With information from here: https://github.com/Arthi-chaud/Meelo/blob/5de296a4b6ceb8d6c04dbc8967909de59632251d/.env.example#L30-L32