### PR TITLE
Fix PUBLIC_MATCHER_URL in prod compose file

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,7 +62,7 @@ services:
       - SSR_SERVER_URL=http://server:4000
       - PUBLIC_SCANNER_URL=${PUBLIC_URL}/scanner
       - SSR_SCANNER_URL=http://scanner:8133
-      - PUBLIC_MATCHER_URL=http://{PUBLIC_URL}/matcher
+      - PUBLIC_MATCHER_URL=${PUBLIC_URL}/matcher
       - SSR_MATCHER_URL=http://matcher:6789
   matcher:
     image: arthichaud/meelo-matcher:${TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - SSR_SERVER_URL=http://server:4000
       - PUBLIC_SCANNER_URL=${PUBLIC_URL}/scanner
       - SSR_SCANNER_URL=http://scanner:8133
-      - PUBLIC_MATCHER_URL=http://{PUBLIC_URL}/matcher
+      - PUBLIC_MATCHER_URL=${PUBLIC_URL}/matcher
       - SSR_MATCHER_URL=http://matcher:6789
   scanner:
     build:


### PR DESCRIPTION
While switching my compose file to the provided one (docker-compose.prod.yml), I ran into errors with the matcher seemingly not working. 
The front would show `Matcher: Status unavailable` in settings and attempts to refresh metadata would fail, despite the matcher container running properly.

The cause was the `PUBLIC_MATCHER_URL` environment variable as it is defined in the compose file. It adds a leading `http://` to `PUBLIC_URL` which already contains it, making the front unable to properly contact the matcher.
It can be fixed by simply using the same format as the other `PUBLIC_*_URL` environment variables.