### PR TITLE
Fix build by removing hardcoded gocv version in WORKDIR

### DIFF
--- a/scanner/Dockerfile.dev
+++ b/scanner/Dockerfile.dev
@@ -1,5 +1,6 @@
 FROM golang:1.25.5-alpine
-RUN go install github.com/bokwoon95/wgo@latest ; go install github.com/swaggo/swag/cmd/swag@latest
+RUN go install github.com/bokwoon95/wgo@latest && \
+    go install github.com/swaggo/swag/cmd/swag@latest
 
 RUN apk update && apk upgrade && apk add ffmpeg chromaprint mailcap make cmake sudo curl pkgconf g++ linux-headers
 
@@ -7,11 +8,11 @@ WORKDIR /app
 
 COPY go.mod go.sum .
 RUN go get -u gocv.io/x/gocv
-WORKDIR /go/pkg/mod/gocv.io/x/gocv@v0.42.0
+WORKDIR /go/pkg/mod/gocv.io/x/
 ENV CGO_ENABLED=1
-RUN make install
+RUN cd gocv@* \
+    && make install
 
 WORKDIR /app
 ENV VERSION=dev
-ENV CGO_ENABLED=1
 CMD ["wgo", "-xdir", "./app/docs", "swag", "init", "-d", "app", "-o", "./app/docs", "::", "go", "run", "./app"]


### PR DESCRIPTION
gocv updated from 0.42 to 0.43 a few days ago. This breaks the dev builds of the scanner image, as the `WORKDIR` had the 0.42.0 version hardcoded in the path.
This fixes it by simply making the path dynamic. `WORKDIR` doesn't support wildcards or being dynamic, so i replaced it with cd.

I also removed a duplicated ENV variable and split the git clone to 2 lines while I was at it, I can remove those changes if you'd prefer the MR to just be the fix.