### PR TITLE
Scanner: Only compute fingerprint if AcoustId is not present in metadata

### DIFF
--- a/scanner/internal/parser/parser.go
+++ b/scanner/internal/parser/parser.go
@@ -59,7 +59,7 @@ func ParseMetadata(config c.UserSettings, filePath string) (internal.Metadata, [
 		getLyricsFromLrc(filePath, config, &metadata)
 	}
 	// Let's save some time by skipping acoustid for unreasonably long media
-	if metadata.Type == internal.Audio || metadata.Duration < 1200 { // 20 minutes
+	if len(metadata.AcoustId) == 0 && (metadata.Type == internal.Audio || metadata.Duration < 1200) { // 20 minutes
 		fingerprint, err := internal.GetFileAcousticFingerprint(filePath)
 		if err != nil {
 			// Fingerprinting failure is not fatal


### PR DESCRIPTION
Wait for #1543 to be closed. Merging this before will break the flow of metadata resolution using AcoustID

Closes #1395