### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/front/apps/mobile/app.config.ts
+++ b/front/apps/mobile/app.config.ts
@@ -57,7 +57,7 @@ export default (_: ConfigContext): ExpoConfig => ({
 			"expo-build-properties",
 			{
 				android: {
-					usesCleartextTraffic: true,
+					usesCleartextTraffic: false,
 				},
 			},
 		],

--- a/front/apps/web/src/components/external-metadata-badge.tsx
+++ b/front/apps/web/src/components/external-metadata-badge.tsx
@@ -26,6 +26,21 @@ type ExternalMetadataBadgeProps = {
 	source: ExternalMetadataSource | undefined;
 };
 
+const getSafeExternalUrl = (url: string | undefined) => {
+	if (!url) {
+		return undefined;
+	}
+	try {
+		const parsedUrl = new URL(url);
+		if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+			return parsedUrl.toString();
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+};
+
 const ExternalMetadataBadge = ({ source }: ExternalMetadataBadgeProps) => {
 	const badge = (
 		<Button
@@ -44,13 +59,11 @@ const ExternalMetadataBadge = ({ source }: ExternalMetadataBadgeProps) => {
 		</Button>
 	);
 
-	if (source?.url) {
+	const safeUrl = getSafeExternalUrl(source?.url);
+
+	if (safeUrl) {
 		return (
-			<Link
-				href={source.url ?? undefined}
-				rel="noopener noreferrer"
-				target="_blank"
-			>
+			<Link href={safeUrl} rel="noopener noreferrer" target="_blank">
 				{badge}
 			</Link>
 		);


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `front/apps/mobile/app.config.ts:L69`

The Expo build properties set `android.usesCleartextTraffic: true`, which allows unencrypted HTTP traffic. If any API/auth traffic is sent over HTTP, attackers on the network can intercept or modify requests/responses (including tokens and session data).

## Solution

Disable cleartext traffic (`usesCleartextTraffic: false`) and enforce HTTPS for all endpoints. If HTTP is needed for local development, gate it behind development-only config and use Android network security config to narrowly allow only specific debug hosts.

## Changes

- `front/apps/mobile/app.config.ts` (modified)
- `front/apps/web/src/components/external-metadata-badge.tsx` (modified)