### PR TITLE
Front: Yarn: enable post install scripts for skia

### DIFF
--- a/front/.yarnrc.yml
+++ b/front/.yarnrc.yml
@@ -1,3 +1,4 @@
 nodeLinker: node-modules
 
+enableScripts: true
 yarnPath: .yarn/releases/yarn-4.14.1.cjs


### PR DESCRIPTION
In v4.14, the option was defaulted to false, preventing the installation of the skia library.