### PR TITLE
Mobile: Fix align of illustration in mini player

### DIFF
--- a/front/apps/mobile/src/components/player/minimised.tsx
+++ b/front/apps/mobile/src/components/player/minimised.tsx
@@ -255,6 +255,7 @@ const styles = StyleSheet.create((theme) => ({
 	infos: {
 		flex: 1,
 		flexDirection: "row",
+		alignItems: "center",
 		gap: theme.gap(1),
 	},
 


### PR DESCRIPTION
The fix is mainly for when the fontsize on the device is greater than normal