### PR TITLE
Add support for "ft. Artist" notation

### DIFF
--- a/server/src/parser/parser.service.spec.ts
+++ b/server/src/parser/parser.service.spec.ts
@@ -244,9 +244,20 @@ describe("Parser Service", () => {
 				"Me Against the Music",
 				["Madonna"],
 			],
+			[
+				"Me Against the Music (ft. Madonna)",
+				"Me Against the Music",
+				["Madonna"],
+			],
 
 			[
 				"Me Against the Music feat. Madonna",
+				"Me Against the Music",
+				["Madonna"],
+			],
+
+			[
+				"Me Against the Music ft. Madonna",
 				"Me Against the Music",
 				["Madonna"],
 			],

--- a/server/src/parser/parser.service.ts
+++ b/server/src/parser/parser.service.ts
@@ -28,7 +28,7 @@ export default class ParserService {
 	constructor(
 		@Inject(forwardRef(() => ArtistService))
 		private artistService: ArtistService,
-	) {}
+	) { }
 
 	protected separators = [
 		[/\(/, /\)/],
@@ -323,7 +323,11 @@ export default class ParserService {
 			.map((ext) => ext.toLowerCase())
 			.filter(
 				(ext) =>
-					!(ext.startsWith("feat ") || ext.startsWith("featuring ")),
+					!(
+						ext.startsWith("feat ") ||
+						ext.startsWith("featuring ") ||
+						ext.startsWith("ft. ")
+					),
 			)
 			.join(" ");
 		const extensionWords = jointExtensionWords.split(" ").flat();
@@ -563,7 +567,11 @@ export default class ParserService {
 			.map((ext) => ext.toLowerCase())
 			.filter(
 				(ext) =>
-					!(ext.startsWith("feat ") || ext.startsWith("featuring ")),
+					!(
+						ext.startsWith("feat ") ||
+						ext.startsWith("featuring ") ||
+						ext.startsWith("ft. ")
+					),
 			)
 			.join(" ");
 		const extensionWords = jointExtensionWords.split(" ").flat();

--- a/server/src/parser/parser.service.ts
+++ b/server/src/parser/parser.service.ts
@@ -28,7 +28,7 @@ export default class ParserService {
 	constructor(
 		@Inject(forwardRef(() => ArtistService))
 		private artistService: ArtistService,
-	) { }
+	) {}
 
 	protected separators = [
 		[/\(/, /\)/],

--- a/server/src/parser/parser.service.ts
+++ b/server/src/parser/parser.service.ts
@@ -205,14 +205,14 @@ export default class ParserService {
 			const [sstart, strippedGroup, ssend] =
 				this.stripGroupDelimiters(group);
 			let featureSubGroup = strippedGroup.match(
-				/(^with|(feat(uring|\.)?))\s+(?<artists>.*)$/i,
+				/(^with|(ft\.?|feat(uring|\.)?))\s+(?<artists>.*)$/i,
 			);
 			let artistGroupIndex = 4;
 
 			if (!sstart && !ssend) {
 				// If there is no delimiters
 				featureSubGroup = strippedGroup.match(
-					/(feat(uring|\.)?)\s+(?<artists>.*)$/i,
+					/(ft\.?|feat(uring|\.)?)\s+(?<artists>.*)$/i,
 				);
 				artistGroupIndex = 3;
 			}


### PR DESCRIPTION
This adds support for the `track ft. Artist` and `track (ft. Artist)` notations.
This is a pretty common alternative to the full spelling of `feat.`, and is commonly seen on MusicBrainz.

I skipped opening an issue since the implementation was really short, feel free to close the MR if it's not something you want to add.