### PR TITLE
fix: transcoder probe and stale nginx upstreams break streaming on the prod compose

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,3 +1,5 @@
+resolver 127.0.0.11 valid=10s ipv6=off;
+
 server {
 	listen ${PORT} default_server;
 	listen [::]:${PORT} default_server;
@@ -8,21 +10,28 @@ server {
 	    return 302 /api/;
 	}
 	location /api/ {
-	    proxy_pass ${SERVER_URL}/;
+	    set $meelo_server ${SERVER_URL};
+	    rewrite ^/api(/.*)$ $1 break;
+	    proxy_pass $meelo_server;
 	}
 	location = /scanner {
 	    return 302 /scanner/;
 	}
 	location /scanner/ {
-	    proxy_pass ${SCANNER_URL}/;
+	    set $meelo_scanner ${SCANNER_URL};
+	    rewrite ^/scanner(/.*)$ $1 break;
+	    proxy_pass $meelo_scanner;
 	}
 	location = /matcher {
 	    return 302 /matcher/;
 	}
 	location /matcher/ {
-	    proxy_pass ${MATCHER_URL}/;
+	    set $meelo_matcher ${MATCHER_URL};
+	    rewrite ^/matcher(/.*)$ $1 break;
+	    proxy_pass $meelo_matcher;
 	}
 	location / {
-		proxy_pass ${FRONT_URL};
+		set $meelo_front ${FRONT_URL};
+		proxy_pass $meelo_front;
 	}
 }

--- a/server/src/stream/stream.service.ts
+++ b/server/src/stream/stream.service.ts
@@ -43,10 +43,12 @@ export class StreamService {
 		this.transcoderUrl = process.env.TRANSCODER_URL ?? null;
 		if (this.transcoderUrl) {
 			this.httpService.axiosRef
-				.get(this.transcoderUrl, { validateStatus: (s) => s < 500 })
+				.get(`${this.transcoderUrl}/video/health`, {
+					// Tolerate 404s so transcoders that predate the
+					// health route still pass as a connectivity check
+					validateStatus: (s) => s < 500,
+				})
 				.then(() => {
-					// there is no healthcheck route atm
-					// knowing that it responded is OK
 					this.logger.log("Transcoder found!");
 				})
 				.catch((_) => {


### PR DESCRIPTION
Hit two independent problems deploying v3.12.0 with docker-compose.prod.yml. Both break streaming on a fresh deployment so I'm fixing them together, as two commits.

### Transcoder probe disables transcoding on every current kyoo build

The server probes `GET /` on the transcoder at boot and disables transcoding on any status >= 500. Current `kyoo_transcoder:master` (and the 5.x releases) answer `GET /` with a 500, so the probe always fails and transcoding stays off for the whole process lifetime. Downgrading to 4.x makes the probe pass, but those builds don't have the `/video/*` routes Meelo proxies to, and 5.1.0 rejects flac with "Selected path is not a video file". So there is currently no transcoder version that works without modification.

The "there is no healthcheck route atm" comment is outdated: kyoo exposes `/video/health` now (it's in their log-exempt paths). This probes that instead. I kept `validateStatus: s < 500` so an older transcoder that 404s on the health route still passes as a plain connectivity check.

The probe still only runs once in the constructor, so if the transcoder comes up after the server you're stuck until a server restart. Happy to look at a retry/lazy re-probe as a follow-up if you're interested (related: #1219).

### nginx keeps proxying to dead container IPs

nginx resolves the hostname in a static `proxy_pass` once, at startup. If only the server container gets recreated (crash, `docker compose restart server`, single-service update), it comes back with a new IP on the docker network and nginx keeps sending `/api` to the old one. Every request 502s and the front shows "Error while parsing Server's response" at login, until nginx is restarted too.

Fixed by using docker's embedded DNS (`resolver 127.0.0.11`) with a variable `proxy_pass`, which re-resolves per request. One gotcha: variable `proxy_pass` disables the implicit URI prefix replacement the old config relied on, so each prefixed location gets an explicit `rewrite ... break`. The mapping is unchanged, `/api/auth/login` still reaches the server as `/auth/login`. The `$meelo_*` variable names are deliberately different from the envsubst ones so the template substitution can't touch them.

### Testing

Ran both fixes on my own deployment (prod compose shape, kyoo_transcoder:master): server logs `Transcoder found!`, flac plays both direct and through the bitrate options (valid HLS playlist), and restarting only the server container no longer 502s everything. `curl -i` on `/api/...` routes returns the same before and after, so prefix stripping is intact. Server test suite passes.
